### PR TITLE
feat: add UI to close about license modals

### DIFF
--- a/src/AboutModal.tsx
+++ b/src/AboutModal.tsx
@@ -173,62 +173,78 @@ const sponsors = [
 ];
 
 export const AboutModal = ({ open, onClose }: AboutModalProps) => {
-  const ref = useModalRef(open);
+  const ref = useModalRef(open, onClose);
 
   return (
-    <dialog
-      ref={ref}
-      onClose={onClose}
-      className="p-5 rounded-lg border-text-base border min-w-min w-[70vw]"
+    <div
+      className={`fixed inset-0 flex items-center justify-center ${open ? "" : "hidden"}`}
     >
-      <p className="py-1">
-        ZMK Studio is made possible thanks to the generous donation of time from
-        our contributors, as well as the financial sponsorship from the
-        following vendors:
-      </p>
-      <div className="grid gap-2 auto-rows-auto grid-cols-[auto_minmax(min-content,1fr)] justify-items-center items-center">
-        {sponsors.map((s) => {
-          const heightVariants = {
-            [SponsorSize.Large]: "h-16",
-            [SponsorSize.Medium]: "h-12",
-            [SponsorSize.Small]: "h-8",
-          };
+      <dialog
+        ref={ref}
+        className="p-5 rounded-lg border-text-base border min-w-min w-[70vw]"
+        open={open}
+        onClose={onClose}
+      >
+        <div className="flex justify-between items-start">
+          <p className="py-1 mr-2">
+            ZMK Studio is made possible thanks to the generous donation of time
+            from our contributors, as well as the financial sponsorship from the
+            following vendors:
+          </p>
+          <button
+            className="p-1.5 rounded-md bg-gray-200 text-black hover:bg-gray-300"
+            onClick={onClose}
+          >
+            Close
+          </button>
+        </div>
+        <div className="grid gap-2 auto-rows-auto grid-cols-[auto_minmax(min-content,1fr)] justify-items-center items-center">
+          {sponsors.map((s) => {
+            const heightVariants = {
+              [SponsorSize.Large]: "h-16",
+              [SponsorSize.Medium]: "h-12",
+              [SponsorSize.Small]: "h-8",
+            };
 
-          return (
-            <>
-              <label>{s.level}</label>
-              <div
-                className={`grid grid-rows-1 gap-x-1 auto-cols-fr grid-flow-col justify-items-center items-center ${
-                  heightVariants[s.size]
-                }`}
-              >
-                {s.vendors.map((v) => {
-                  const maxSizeVariants = {
-                    [SponsorSize.Large]: "max-h-16",
-                    [SponsorSize.Medium]: "max-h-12",
-                    [SponsorSize.Small]: "max-h-8",
-                  };
+            return (
+              <>
+                <label>{s.level}</label>
+                <div
+                  className={`grid grid-rows-1 gap-x-1 auto-cols-fr grid-flow-col justify-items-center items-center ${
+                    heightVariants[s.size]
+                  }`}
+                >
+                  {s.vendors.map((v) => {
+                    const maxSizeVariants = {
+                      [SponsorSize.Large]: "max-h-16",
+                      [SponsorSize.Medium]: "max-h-12",
+                      [SponsorSize.Small]: "max-h-8",
+                    };
 
-                  return (
-                    <a href={v.url} target="_blank">
-                      <picture aria-label={v.name}>
-                        {v.darkModeImg && (
-                          <source
+                    return (
+                      <a href={v.url} target="_blank">
+                        <picture aria-label={v.name}>
+                          {v.darkModeImg && (
+                            <source
+                              className={maxSizeVariants[s.size]}
+                              srcSet={v.darkModeImg}
+                              media="(prefers-color-scheme: dark)"
+                            />
+                          )}
+                          <img
                             className={maxSizeVariants[s.size]}
-                            srcSet={v.darkModeImg}
-                            media="(prefers-color-scheme: dark)"
+                            src={v.img}
                           />
-                        )}
-                        <img className={maxSizeVariants[s.size]} src={v.img} />
-                      </picture>
-                    </a>
-                  );
-                })}
-              </div>
-            </>
-          );
-        })}
-      </div>
-    </dialog>
+                        </picture>
+                      </a>
+                    );
+                  })}
+                </div>
+              </>
+            );
+          })}
+        </div>
+      </dialog>
+    </div>
   );
 };

--- a/src/AboutModal.tsx
+++ b/src/AboutModal.tsx
@@ -176,9 +176,7 @@ export const AboutModal = ({ open, onClose }: AboutModalProps) => {
   const ref = useModalRef(open, onClose);
 
   return (
-    <div
-      className={`fixed inset-0 flex items-center justify-center ${open ? "" : "hidden"}`}
-    >
+    <div className="fixed inset-0 flex items-center justify-center">
       <dialog
         ref={ref}
         className="p-5 rounded-lg border-text-base border min-w-min w-[70vw]"

--- a/src/AboutModal.tsx
+++ b/src/AboutModal.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useModalRef } from "./misc/useModalRef";
 
 import cannonKeys from "./assets/cannonkeys.png";
@@ -173,76 +174,70 @@ const sponsors = [
 ];
 
 export const AboutModal = ({ open, onClose }: AboutModalProps) => {
-  const ref = useModalRef(open, onClose);
+  const ref = useModalRef(open, true);
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center">
-      <dialog
-        ref={ref}
-        className="p-5 rounded-lg border-text-base border min-w-min w-[70vw]"
-        open={open}
-        onClose={onClose}
-      >
-        <div className="flex justify-between items-start">
-          <p className="py-1 mr-2">
-            ZMK Studio is made possible thanks to the generous donation of time
-            from our contributors, as well as the financial sponsorship from the
-            following vendors:
-          </p>
-          <button
-            className="p-1.5 rounded-md bg-gray-200 text-black hover:bg-gray-300"
-            onClick={onClose}
-          >
-            Close
-          </button>
-        </div>
-        <div className="grid gap-2 auto-rows-auto grid-cols-[auto_minmax(min-content,1fr)] justify-items-center items-center">
-          {sponsors.map((s) => {
-            const heightVariants = {
-              [SponsorSize.Large]: "h-16",
-              [SponsorSize.Medium]: "h-12",
-              [SponsorSize.Small]: "h-8",
-            };
+    <dialog
+      ref={ref}
+      className="p-5 rounded-lg border-text-base border min-w-min w-[70vw]"
+      onClose={onClose}
+    >
+      <div className="flex justify-between items-start">
+        <p className="py-1 mr-2">
+          ZMK Studio is made possible thanks to the generous donation of time
+          from our contributors, as well as the financial sponsorship from the
+          following vendors:
+        </p>
+        <button
+          className="p-1.5 rounded-md bg-gray-100 text-black hover:bg-gray-300"
+          onClick={onClose}
+        >
+          Close
+        </button>
+      </div>
+      <div className="grid gap-2 auto-rows-auto grid-cols-[auto_minmax(min-content,1fr)] justify-items-center items-center">
+        {sponsors.map((s) => {
+          const heightVariants = {
+            [SponsorSize.Large]: "h-16",
+            [SponsorSize.Medium]: "h-12",
+            [SponsorSize.Small]: "h-8",
+          };
 
-            return (
-              <>
-                <label>{s.level}</label>
-                <div
-                  className={`grid grid-rows-1 gap-x-1 auto-cols-fr grid-flow-col justify-items-center items-center ${
-                    heightVariants[s.size]
-                  }`}
-                >
-                  {s.vendors.map((v) => {
-                    const maxSizeVariants = {
-                      [SponsorSize.Large]: "max-h-16",
-                      [SponsorSize.Medium]: "max-h-12",
-                      [SponsorSize.Small]: "max-h-8",
-                    };
+          return (
+            <React.Fragment key={s.level}>
+              <label>{s.level}</label>
+              <div
+                className={`grid grid-rows-1 gap-x-1 auto-cols-fr grid-flow-col justify-items-center items-center ${
+                  heightVariants[s.size]
+                }`}
+              >
+                {s.vendors.map((v) => {
+                  const maxSizeVariants = {
+                    [SponsorSize.Large]: "max-h-16",
+                    [SponsorSize.Medium]: "max-h-12",
+                    [SponsorSize.Small]: "max-h-8",
+                  };
 
-                    return (
-                      <a href={v.url} target="_blank">
-                        <picture aria-label={v.name}>
-                          {v.darkModeImg && (
-                            <source
-                              className={maxSizeVariants[s.size]}
-                              srcSet={v.darkModeImg}
-                              media="(prefers-color-scheme: dark)"
-                            />
-                          )}
-                          <img
+                  return (
+                    <a key={v.name} href={v.url} target="_blank">
+                      <picture aria-label={v.name}>
+                        {v.darkModeImg && (
+                          <source
                             className={maxSizeVariants[s.size]}
-                            src={v.img}
+                            srcSet={v.darkModeImg}
+                            media="(prefers-color-scheme: dark)"
                           />
-                        </picture>
-                      </a>
-                    );
-                  })}
-                </div>
-              </>
-            );
-          })}
-        </div>
-      </dialog>
-    </div>
+                        )}
+                        <img className={maxSizeVariants[s.size]} src={v.img} />
+                      </picture>
+                    </a>
+                  );
+                })}
+              </div>
+            </React.Fragment>
+          );
+        })}
+      </div>
+    </dialog>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,11 +289,15 @@ function App() {
             transports={TRANSPORTS}
             onTransportCreated={onConnect}
           />
-          <AboutModal open={showAbout} onClose={() => setShowAbout(false)} />
-          <LicenseNoticeModal
-            open={showLicenseNotice}
-            onClose={() => setShowLicenseNotice(false)}
-          />
+          {showAbout && (
+            <AboutModal open={showAbout} onClose={() => setShowAbout(false)} />
+          )}
+          {showLicenseNotice && (
+            <LicenseNoticeModal
+              open={showLicenseNotice}
+              onClose={() => setShowLicenseNotice(false)}
+            />
+          )}
           <div className="bg-bg-base text-text-base h-full w-full min-w-min inline-grid grid-cols-[auto] grid-rows-[auto_1fr_auto]">
             <AppHeader
               connectedDeviceLabel={connectedDeviceName}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -289,15 +289,11 @@ function App() {
             transports={TRANSPORTS}
             onTransportCreated={onConnect}
           />
-          {showAbout && (
-            <AboutModal open={showAbout} onClose={() => setShowAbout(false)} />
-          )}
-          {showLicenseNotice && (
-            <LicenseNoticeModal
-              open={showLicenseNotice}
-              onClose={() => setShowLicenseNotice(false)}
-            />
-          )}
+          <AboutModal open={showAbout} onClose={() => setShowAbout(false)} />
+          <LicenseNoticeModal
+            open={showLicenseNotice}
+            onClose={() => setShowLicenseNotice(false)}
+          />
           <div className="bg-bg-base text-text-base h-full w-full min-w-min inline-grid grid-cols-[auto] grid-rows-[auto_1fr_auto]">
             <AppHeader
               connectedDeviceLabel={connectedDeviceName}

--- a/src/misc/LicenseNoticeModal.tsx
+++ b/src/misc/LicenseNoticeModal.tsx
@@ -14,9 +14,7 @@ export const LicenseNoticeModal = ({
   const ref = useModalRef(open, onClose);
 
   return (
-    <div
-      className={`fixed inset-0 flex items-center justify-center ${open ? "" : "hidden"}`}
-    >
+    <div className="fixed inset-0 flex items-center justify-center">
       <dialog
         ref={ref}
         className="p-5 rounded-lg border-text-base border min-w-min w-[60vw]"

--- a/src/misc/LicenseNoticeModal.tsx
+++ b/src/misc/LicenseNoticeModal.tsx
@@ -11,21 +11,35 @@ export const LicenseNoticeModal = ({
   open,
   onClose,
 }: LicenseNoticeModalProps) => {
-  const ref = useModalRef(open);
+  const ref = useModalRef(open, onClose);
+
   return (
-    <dialog
-      ref={ref}
-      onClose={onClose}
-      className="p-5 rounded-lg border-text-base border min-w-min w-[60vw]"
+    <div
+      className={`fixed inset-0 flex items-center justify-center ${open ? "" : "hidden"}`}
     >
-      <div>
-        <p>
-          ZMK Studio is released under the open source Apache 2.0 license. A
-          copy of the NOTICE file from the ZMK Studio repository is included
-          here:
-        </p>
-        <pre className="m-4 font-mono text-xs">{NOTICE}</pre>
-      </div>
-    </dialog>
+      <dialog
+        ref={ref}
+        className="p-5 rounded-lg border-text-base border min-w-min w-[60vw]"
+        open={open}
+        onClose={onClose}
+      >
+        <div>
+          <div className="flex justify-between items-start">
+            <p className="mr-2">
+              ZMK Studio is released under the open source Apache 2.0 license. A
+              copy of the NOTICE file from the ZMK Studio repository is included
+              here:
+            </p>
+            <button
+              className="p-1.5 rounded-md bg-gray-200 text-black hover:bg-gray-300"
+              onClick={onClose}
+            >
+              Close
+            </button>
+          </div>
+          <pre className="m-4 font-mono text-xs">{NOTICE}</pre>
+        </div>
+      </dialog>
+    </div>
   );
 };

--- a/src/misc/LicenseNoticeModal.tsx
+++ b/src/misc/LicenseNoticeModal.tsx
@@ -11,33 +11,30 @@ export const LicenseNoticeModal = ({
   open,
   onClose,
 }: LicenseNoticeModalProps) => {
-  const ref = useModalRef(open, onClose);
+  const ref = useModalRef(open, true);
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center">
-      <dialog
-        ref={ref}
-        className="p-5 rounded-lg border-text-base border min-w-min w-[60vw]"
-        open={open}
-        onClose={onClose}
-      >
-        <div>
-          <div className="flex justify-between items-start">
-            <p className="mr-2">
-              ZMK Studio is released under the open source Apache 2.0 license. A
-              copy of the NOTICE file from the ZMK Studio repository is included
-              here:
-            </p>
-            <button
-              className="p-1.5 rounded-md bg-gray-200 text-black hover:bg-gray-300"
-              onClick={onClose}
-            >
-              Close
-            </button>
-          </div>
-          <pre className="m-4 font-mono text-xs">{NOTICE}</pre>
+    <dialog
+      ref={ref}
+      className="p-5 rounded-lg border-text-base border min-w-min w-[60vw]"
+      onClose={onClose}
+    >
+      <div>
+        <div className="flex justify-between items-start">
+          <p className="mr-2">
+            ZMK Studio is released under the open source Apache 2.0 license. A
+            copy of the NOTICE file from the ZMK Studio repository is included
+            here:
+          </p>
+          <button
+            className="p-1.5 rounded-md bg-gray-100 text-black hover:bg-gray-300"
+            onClick={onClose}
+          >
+            Close
+          </button>
         </div>
-      </dialog>
-    </div>
+        <pre className="m-4 font-mono text-xs">{NOTICE}</pre>
+      </div>
+    </dialog>
   );
 };

--- a/src/misc/useModalRef.ts
+++ b/src/misc/useModalRef.ts
@@ -1,7 +1,8 @@
 import { MutableRefObject, useEffect, useRef } from "react";
 
 export function useModalRef(
-  open: boolean
+  open: boolean,
+  onClose?: () => void,
 ): MutableRefObject<HTMLDialogElement | null> {
   const ref = useRef<HTMLDialogElement | null>(null);
 
@@ -14,6 +15,32 @@ export function useModalRef(
       ref.current?.close();
     }
   }, [open]);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (
+        onClose &&
+        open &&
+        ref.current &&
+        !ref.current.contains(event.target as Node)
+      ) {
+        onClose();
+      }
+    };
+    const handleEscKey = (event: KeyboardEvent) => {
+      if (onClose && event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscKey);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscKey);
+    };
+  }, [open, onClose]);
 
   return ref;
 }


### PR DESCRIPTION
## Changes

- add close button to About and License modals
- add UX to close About and License modals by clicking outside modal

| Before | After |
| ----- | ----- |
| <img alt="image" src="https://github.com/user-attachments/assets/b2e326e0-c431-438c-8850-d64817b3c25d"> | <img alt="image" src="https://github.com/user-attachments/assets/8b069fb4-3db1-405d-9cfa-9fdabbe65ab2"> |
| <img width="1048" alt="image" src="https://github.com/user-attachments/assets/3769a74d-d7a0-40a6-993c-8ee6425adfd9"> | <img width="1049" alt="image" src="https://github.com/user-attachments/assets/88dd1e97-4847-46f4-8ffc-d554b370c7d5"> |