### PR TITLE
fix: replace edit label prompt with modal

### DIFF
--- a/src/keyboard/LayerPicker.tsx
+++ b/src/keyboard/LayerPicker.tsx
@@ -85,19 +85,23 @@ const EditLabelModal = ({
           }
         }}
       />
-      <div className="m-2 flex justify-end">
-        <button type="button" aria-label="Cancel Edit" onClick={onClose}>
-          <XMarkIcon className="h-7 w-7 mx-1 hover:text-accent" />
+      <div className="mt-4 flex justify-end">
+        <button
+          className="py-1.5 px-2"
+          type="button"
+          onClick={onClose}
+        >
+          Cancel
         </button>
         <button
+          className="py-1.5 px-2 ml-4 rounded-md bg-gray-100 text-black hover:bg-gray-300"
           type="button"
-          aria-label="Save Edit"
           onClick={(e) => {
             e.preventDefault();
             handleSave();
           }}
         >
-          <CheckIcon className="h-7 w-7 mx-1 hover:text-accent" />
+          Save
         </button>
       </div>
     </dialog>
@@ -137,7 +141,7 @@ export const LayerPicker = ({
 
       onLayerClicked?.(layer_items.findIndex((l) => s.has(l.id)));
     },
-    [onLayerClicked, layer_items]
+    [onLayerClicked, layer_items],
   );
 
   let { dragAndDropHooks } = useDragAndDrop({

--- a/src/keyboard/LayerPicker.tsx
+++ b/src/keyboard/LayerPicker.tsx
@@ -71,7 +71,7 @@ const EditLabelModal = ({
       onClose={onClose}
       className="p-5 rounded-lg border-text-base border min-w-min w-[30vw] flex flex-col"
     >
-      <span className="mb-3 text-lg">Editing Layer Name</span>
+      <span className="mb-3 text-lg">New Layer Name</span>
       <input
         className="p-1 border rounded border-text-base border-solid"
         ref={labelInputRef}

--- a/src/keyboard/LayerPicker.tsx
+++ b/src/keyboard/LayerPicker.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, PencilIcon, XMarkIcon } from "@heroicons/react/24/solid";
+import { PencilIcon } from "@heroicons/react/24/solid";
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
   DropIndicator,

--- a/src/keyboard/LayerPicker.tsx
+++ b/src/keyboard/LayerPicker.tsx
@@ -1,5 +1,5 @@
 import { PencilIcon } from "@heroicons/react/24/solid";
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import {
   DropIndicator,
   Label,
@@ -56,28 +56,26 @@ const EditLabelModal = ({
   ) => void;
 }) => {
   const ref = useModalRef(open);
-  const labelInputRef = useRef<HTMLInputElement>(null);
+  const [newLabelName, setNewLabelName] = useState(editLabelData.name);
 
   const handleSave = () => {
-    const newName = labelInputRef.current?.value ?? null;
-    handleSaveNewLabel(editLabelData.id, editLabelData.name, newName);
+    handleSaveNewLabel(editLabelData.id, editLabelData.name, newLabelName);
     onClose();
   };
 
   return (
     <dialog
       ref={ref}
-      defaultValue={editLabelData.name}
       onClose={onClose}
       className="p-5 rounded-lg border-text-base border min-w-min w-[30vw] flex flex-col"
     >
       <span className="mb-3 text-lg">New Layer Name</span>
       <input
         className="p-1 border rounded border-text-base border-solid"
-        ref={labelInputRef}
         type="text"
         defaultValue={editLabelData.name}
         autoFocus
+        onChange={(e) => setNewLabelName(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === "Enter") {
             e.preventDefault();
@@ -86,18 +84,13 @@ const EditLabelModal = ({
         }}
       />
       <div className="mt-4 flex justify-end">
-        <button
-          className="py-1.5 px-2"
-          type="button"
-          onClick={onClose}
-        >
+        <button className="py-1.5 px-2" type="button" onClick={onClose}>
           Cancel
         </button>
         <button
           className="py-1.5 px-2 ml-4 rounded-md bg-gray-100 text-black hover:bg-gray-300"
           type="button"
-          onClick={(e) => {
-            e.preventDefault();
+          onClick={() => {
             handleSave();
           }}
         >


### PR DESCRIPTION
## Changes

These changes replace the edit label prompt with a modal  to address the prompt not showing up in the macOS app (assuming it is a permissions issue)

| Before | After |
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/827a4a6b-769d-4b9c-a75e-3d3bae2cca6f) | <img src="https://github.com/user-attachments/assets/c1596848-a63a-4a11-8a61-b2c078d74267" width="1167"> |
