### PR TITLE
feat: Auto-zoom keymap layout

### DIFF
--- a/src/keyboard/Keyboard.tsx
+++ b/src/keyboard/Keyboard.tsx
@@ -29,7 +29,7 @@ import { BehaviorBindingPicker } from "../behaviors/BehaviorBindingPicker";
 import { produce } from "immer";
 import { LockStateContext } from "../rpc/LockStateContext";
 import { LockState } from "@zmkfirmware/zmk-studio-ts-client/core";
-import { LayoutZoom } from "./PhysicalLayout";
+import { deserializeLayoutZoom, LayoutZoom } from "./PhysicalLayout";
 import { useLocalStorageState } from "../misc/useLocalStorageState";
 
 type BehaviorMap = Record<number, GetBehaviorDetailsResponse>;
@@ -175,12 +175,7 @@ export default function Keyboard() {
   );
 
   const [keymapScale, setKeymapScale] = useLocalStorageState<LayoutZoom>("keymapScale", "auto", {
-    deserialize: (value) => {
-      if (value === "auto") {
-        return "auto";
-      }
-      return parseFloat(value) || "auto";
-    }
+    deserialize: deserializeLayoutZoom,
   });
 
   const [selectedLayerIndex, setSelectedLayerIndex] = useState<number>(0);
@@ -539,12 +534,8 @@ export default function Keyboard() {
             className="absolute top-2 right-2 h-8 rounded px-2"
             value={keymapScale}
             onChange={(e) => {
-              const value = e.target.value;
-              if (value === "auto") {
-                setKeymapScale("auto");
-              } else {
-                setKeymapScale(parseFloat(value));
-              }
+              const value = deserializeLayoutZoom(e.target.value);
+              setKeymapScale(value);
             }}
           >
             <option value="auto">Auto</option>

--- a/src/keyboard/Keyboard.tsx
+++ b/src/keyboard/Keyboard.tsx
@@ -29,6 +29,7 @@ import { BehaviorBindingPicker } from "../behaviors/BehaviorBindingPicker";
 import { produce } from "immer";
 import { LockStateContext } from "../rpc/LockStateContext";
 import { LockState } from "@zmkfirmware/zmk-studio-ts-client/core";
+import { LayoutZoom } from "./PhysicalLayout";
 
 type BehaviorMap = Record<number, GetBehaviorDetailsResponse>;
 
@@ -172,6 +173,7 @@ export default function Keyboard() {
     true
   );
 
+  const [keymapScale, setKeymapScale] = useState<LayoutZoom>("auto");
   const [selectedLayerIndex, setSelectedLayerIndex] = useState<number>(0);
   const [selectedKeyPosition, setSelectedKeyPosition] = useState<
     number | undefined
@@ -514,15 +516,37 @@ export default function Keyboard() {
         )}
       </div>
       {layouts && keymap && behaviors && (
-        <div className="col-start-2 row-start-1 grid items-center justify-center">
+        <div className="col-start-2 row-start-1 grid items-center justify-center relative">
           <KeymapComp
             keymap={keymap}
             layout={layouts[selectedPhysicalLayoutIndex]}
             behaviors={behaviors}
+            scale={keymapScale}
             selectedLayerIndex={selectedLayerIndex}
             selectedKeyPosition={selectedKeyPosition}
             onKeyPositionClicked={setSelectedKeyPosition}
           />
+          <select
+            className="absolute top-2 right-2 h-8 rounded px-2"
+            value={keymapScale}
+            onChange={(e) => {
+              const value = e.target.value;
+              if (value === "auto") {
+                setKeymapScale("auto");
+              } else {
+                setKeymapScale(parseFloat(value));
+              }
+            }}
+          >
+            <option value="auto">Auto</option>
+            <option value={0.25}>25%</option>
+            <option value={0.5}>50%</option>
+            <option value={0.75}>75%</option>
+            <option value={1}>100%</option>
+            <option value={1.25}>125%</option>
+            <option value={1.5}>150%</option>
+            <option value={2}>200%</option>
+          </select>
         </div>
       )}
       {keymap && selectedBinding && (

--- a/src/keyboard/Keyboard.tsx
+++ b/src/keyboard/Keyboard.tsx
@@ -30,6 +30,7 @@ import { produce } from "immer";
 import { LockStateContext } from "../rpc/LockStateContext";
 import { LockState } from "@zmkfirmware/zmk-studio-ts-client/core";
 import { LayoutZoom } from "./PhysicalLayout";
+import { useLocalStorageState } from "../misc/useLocalStorageState";
 
 type BehaviorMap = Record<number, GetBehaviorDetailsResponse>;
 
@@ -173,14 +174,14 @@ export default function Keyboard() {
     true
   );
 
-  const [keymapScale, setKeymapScale] = useState<LayoutZoom>(() => {
-    const savedValue = localStorage.getItem("keymapScale");
-    return savedValue === null || savedValue === "auto" ? "auto" : parseFloat(savedValue) || "auto";
+  const [keymapScale, setKeymapScale] = useLocalStorageState<LayoutZoom>("keymapScale", "auto", {
+    deserialize: (value) => {
+      if (value === "auto") {
+        return "auto";
+      }
+      return parseFloat(value) || "auto";
+    }
   });
-
-  useEffect(() => {
-    localStorage.setItem("keymapScale", keymapScale.toString());
-  }, [keymapScale]);
 
   const [selectedLayerIndex, setSelectedLayerIndex] = useState<number>(0);
   const [selectedKeyPosition, setSelectedKeyPosition] = useState<

--- a/src/keyboard/Keyboard.tsx
+++ b/src/keyboard/Keyboard.tsx
@@ -173,7 +173,15 @@ export default function Keyboard() {
     true
   );
 
-  const [keymapScale, setKeymapScale] = useState<LayoutZoom>("auto");
+  const [keymapScale, setKeymapScale] = useState<LayoutZoom>(() => {
+    const savedValue = localStorage.getItem("keymapScale");
+    return savedValue === null || savedValue === "auto" ? "auto" : parseFloat(savedValue) || "auto";
+  });
+
+  useEffect(() => {
+    localStorage.setItem("keymapScale", keymapScale.toString());
+  }, [keymapScale]);
+
   const [selectedLayerIndex, setSelectedLayerIndex] = useState<number>(0);
   const [selectedKeyPosition, setSelectedKeyPosition] = useState<
     number | undefined

--- a/src/keyboard/Keymap.tsx
+++ b/src/keyboard/Keymap.tsx
@@ -9,7 +9,7 @@ import {
   hid_usage_page_and_id_from_usage,
 } from "../hid-usages";
 
-import { PhysicalLayout as PhysicalLayoutComp } from "./PhysicalLayout";
+import { LayoutZoom, PhysicalLayout as PhysicalLayoutComp } from "./PhysicalLayout";
 
 type BehaviorMap = Record<number, GetBehaviorDetailsResponse>;
 
@@ -17,6 +17,7 @@ export interface KeymapProps {
   layout: PhysicalLayout;
   keymap: KeymapMsg;
   behaviors: BehaviorMap;
+  scale: LayoutZoom;
   selectedLayerIndex: number;
   selectedKeyPosition: number | undefined;
   onKeyPositionClicked: (keyPosition: number) => void;
@@ -26,6 +27,7 @@ export const Keymap = ({
   layout,
   keymap,
   behaviors,
+  scale,
   selectedLayerIndex,
   selectedKeyPosition,
   onKeyPositionClicked,
@@ -75,6 +77,7 @@ export const Keymap = ({
       positions={positions}
       oneU={48}
       hoverZoom={true}
+      zoom={scale}
       selectedPosition={selectedKeyPosition}
       onPositionClicked={onKeyPositionClicked}
     />

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -82,9 +82,10 @@ export const PhysicalLayout = ({
 
     const calculateScale = () => {
       if (props.zoom === "auto") {
+        const padding = 50; // Padding when in auto mode
         const newScale = Math.min(
-          parent.clientWidth / element.clientWidth,
-          parent.clientHeight / element.clientHeight,
+          parent.clientWidth / (element.clientWidth + 2 * padding),
+          parent.clientHeight / (element.clientHeight + 2 * padding),
         );
         setScale(newScale);
       } else {
@@ -133,20 +134,16 @@ export const PhysicalLayout = ({
 
   return (
     <div
-      className="p-12 box-content"
+      className="relative"
+      style={{
+        height: bottomMost * oneU + "px",
+        width: rightMost * oneU + "px",
+        transform: `scale(${scale})`,
+      }}
       ref={ref}
-      style={{ transform: `scale(${scale})` }}
+      {...props}
     >
-      <div
-        className="relative"
-        style={{
-          height: bottomMost * oneU + "px",
-          width: rightMost * oneU + "px",
-        }}
-        {...props}
-      >
-        {positionItems}
-      </div>
+      {positionItems}
     </div>
   );
 };

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -20,6 +20,13 @@ export type KeyPosition = PropsWithChildren<{
 
 export type LayoutZoom = number | "auto";
 
+export function deserializeLayoutZoom(value: string): LayoutZoom {
+  if (value === "auto") {
+    return "auto";
+  }
+  return parseFloat(value) || "auto";
+}
+
 interface PhysicalLayoutProps {
   positions: Array<KeyPosition>;
   selectedPosition?: number;

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -82,7 +82,7 @@ export const PhysicalLayout = ({
 
     const calculateScale = () => {
       if (props.zoom === "auto") {
-        const padding = 50; // Padding when in auto mode
+        const padding = Math.min(window.innerWidth, window.innerHeight) * 0.05; // Padding when in auto mode
         const newScale = Math.min(
           parent.clientWidth / (element.clientWidth + 2 * padding),
           parent.clientHeight / (element.clientHeight + 2 * padding),

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -1,7 +1,7 @@
 import {
   CSSProperties,
   PropsWithChildren,
-  useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react";
@@ -73,7 +73,7 @@ export const PhysicalLayout = ({
   const ref = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const element = ref.current;
     if (!element) return;
 

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -133,7 +133,7 @@ export const PhysicalLayout = ({
 
   return (
     <div
-      className="p-4 box-content"
+      className="p-12 box-content"
       ref={ref}
       style={{ transform: `scale(${scale})` }}
     >

--- a/src/misc/useLocalStorageState.ts
+++ b/src/misc/useLocalStorageState.ts
@@ -1,6 +1,20 @@
 import { useEffect, useState } from "react";
 
-export function useLocalStorageState<T>(key: string, defaultValue: T, options?: { serialize?: (value: T) => string; deserialize?: (value: string) => T; }) {
+function basicSerialize<T>(value: T): string {
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+export function useLocalStorageState<T>(
+  key: string,
+  defaultValue: T,
+  options?: {
+    serialize?: (value: T) => string;
+    deserialize?: (value: string) => T;
+  },
+) {
   const reactState = useState<T>(() => {
     const savedValue = localStorage.getItem(key);
     if (savedValue !== null) {
@@ -10,15 +24,13 @@ export function useLocalStorageState<T>(key: string, defaultValue: T, options?: 
       return savedValue as T; // Assuming T is a string
     }
     return defaultValue;
-  })
+  });
 
   const [state] = reactState;
 
   useEffect(() => {
-    const serializedState = options?.serialize?(state) || 
-      ((typeof state === 'object' && state !== null)
-        ? JSON.stringify(state) // Fallback for objects
-        : String(state)); // Fallback for other types
+    const serializedState =
+      options?.serialize?.(state) || basicSerialize(state);
     localStorage.setItem(key, serializedState);
   }, [state, key, options]);
 

--- a/src/misc/useLocalStorageState.ts
+++ b/src/misc/useLocalStorageState.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+export function useLocalStorageState<T>(key: string, defaultValue: T, options?: { serialize?: (value: T) => string; deserialize?: (value: string) => T; }) {
+  const [state, setState] = useState<T>(() => {
+    const savedValue = localStorage.getItem(key);
+    if (savedValue !== null) {
+      if (options?.deserialize) {
+        return options.deserialize(savedValue);
+      }
+      return savedValue as T; // Assuming T is a string
+    }
+    return defaultValue;
+  })
+
+  useEffect(() => {
+    const serializedState = options?.serialize ? options.serialize(state)
+      : (typeof state === 'object' && state !== null)
+        ? JSON.stringify(state) // Fallback for objects
+        : String(state); // Fallback for other types
+    localStorage.setItem(key, serializedState);
+  }, [state, key, options]);
+
+  return [state, setState];
+}

--- a/src/misc/useLocalStorageState.ts
+++ b/src/misc/useLocalStorageState.ts
@@ -15,10 +15,10 @@ export function useLocalStorageState<T>(key: string, defaultValue: T, options?: 
   const [state] = reactState;
 
   useEffect(() => {
-    const serializedState = options?.serialize ? options.serialize(state)
-      : (typeof state === 'object' && state !== null)
+    const serializedState = options?.serialize?(state) || 
+      ((typeof state === 'object' && state !== null)
         ? JSON.stringify(state) // Fallback for objects
-        : String(state); // Fallback for other types
+        : String(state)); // Fallback for other types
     localStorage.setItem(key, serializedState);
   }, [state, key, options]);
 

--- a/src/misc/useLocalStorageState.ts
+++ b/src/misc/useLocalStorageState.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 export function useLocalStorageState<T>(key: string, defaultValue: T, options?: { serialize?: (value: T) => string; deserialize?: (value: string) => T; }) {
-  const [state, setState] = useState<T>(() => {
+  const reactState = useState<T>(() => {
     const savedValue = localStorage.getItem(key);
     if (savedValue !== null) {
       if (options?.deserialize) {
@@ -12,6 +12,8 @@ export function useLocalStorageState<T>(key: string, defaultValue: T, options?: 
     return defaultValue;
   })
 
+  const [state] = reactState;
+
   useEffect(() => {
     const serializedState = options?.serialize ? options.serialize(state)
       : (typeof state === 'object' && state !== null)
@@ -20,5 +22,5 @@ export function useLocalStorageState<T>(key: string, defaultValue: T, options?: 
     localStorage.setItem(key, serializedState);
   }, [state, key, options]);
 
-  return [state, setState];
+  return reactState;
 }


### PR DESCRIPTION
Adds auto scaling the keymap/layout to fit available space. Adds a selection in the top right to override auto to a specific percentage zoom, too.

![image](https://github.com/user-attachments/assets/99a63d77-8a96-4249-83a3-f7a7b85f1a66)
