### PR TITLE
chore: Tauri build only on release publish

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
   release:
-    type: [published]
+    types: [published]
 
 jobs:
   publish-tauri:


### PR DESCRIPTION
* Fix the GHA filter for release triggers to only run on published release event.