### PR TITLE
fix: Add link to unlock behavior docs in unlock modal

### DIFF
--- a/src/UnlockModal.tsx
+++ b/src/UnlockModal.tsx
@@ -7,6 +7,7 @@ import { LockState } from "@zmkfirmware/zmk-studio-ts-client/core";
 import { ConnectionContext } from "./rpc/ConnectionContext";
 import { useModalRef } from "./misc/useModalRef";
 import { GenericModal } from "./GenericModal";
+import { ExternalLink } from "./misc/ExternalLink";
 
 export type TransportFactory = {
   label: string;
@@ -36,6 +37,13 @@ export const UnlockModal = ({}: UnlockModalProps) => {
       <p>
         For security reasons, your keyboard requires unlocking before using ZMK
         Studio.
+      </p>
+      <p>
+        If studio unlocking hasn't been added to your keymap or a combo, see the{" "}
+        <ExternalLink href="https://zmk.dev/docs/keymaps/behaviors/studio-unlock">
+          Studio Unlock Behavior
+        </ExternalLink>{" "}
+        documentation for more infomation.
       </p>
     </GenericModal>
   );


### PR DESCRIPTION
To help new studio users, add a link to the unlock behavior docs directly in the unlock modal.