### PR TITLE
chore(improve-modal): modal-dialog 

### DIFF
--- a/src/AboutModal.tsx
+++ b/src/AboutModal.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { useModalRef } from "./misc/useModalRef";
+import React, { FC, PropsWithChildren, useState } from "react";
 
 import cannonKeys from "./assets/cannonkeys.png";
 import cannonKeysDarkMode from "./assets/cannonkeys-dark-mode.png";
@@ -40,13 +39,8 @@ import mekiboDarkMode from "./assets/mekibo-dark-mode.png";
 
 import splitkb from "./assets/splitkb.png";
 import splitkbDarkMode from "./assets/splitkb-dark-mode.png";
-import { GenericModal } from "./GenericModal";
 import { ExternalLink } from "./misc/ExternalLink";
-
-export interface AboutModalProps {
-  open: boolean;
-  onClose: () => void;
-}
+import { Modal, ModalContent } from "./components/modal/Modal";
 
 enum SponsorSize {
   Large,
@@ -175,80 +169,87 @@ const sponsors = [
   },
 ];
 
-export const AboutModal = ({ open, onClose }: AboutModalProps) => {
-  const ref = useModalRef(open, true);
-
+export const AboutModal: FC<PropsWithChildren> = ({ children }) => {
+  const [open, setOpen] = useState(false);
   return (
-    <GenericModal ref={ref} className="min-w-min w-[70vw]" onClose={onClose}>
-      <div className="flex justify-between items-start">
-        <p>
-          The ZMK Project:{" "}
-          <ExternalLink href="https://zmk.dev/">website</ExternalLink>,{" "}
-          <ExternalLink href="https://github.com/zmkfirmware/zmk/issues/">
-            GitHub Issues
-          </ExternalLink>
-          ,{" "}
-          <ExternalLink href="https://zmk.dev/community/discord/invite">
-            Discord Server
-          </ExternalLink>
-        </p>
-        <button
-          className="p-1.5 rounded-md bg-gray-100 text-black hover:bg-gray-300"
-          onClick={onClose}
-        >
-          Close
-        </button>
-      </div>
-      <div>
-        <p className="py-1 mr-2">
-          ZMK Studio is made possible thanks to the generous donation of time
-          from our contributors, as well as the financial sponsorship from the
-          following vendors:
-        </p>
-      </div>
-      <div className="grid gap-2 auto-rows-auto grid-cols-[auto_minmax(min-content,1fr)] justify-items-center items-center">
-        {sponsors.map((s) => {
-          const heightVariants = {
-            [SponsorSize.Large]: "h-16",
-            [SponsorSize.Medium]: "h-12",
-            [SponsorSize.Small]: "h-8",
-          };
+    <>
+      <a
+        role="button"
+        className="hover:text-primary hover:cursor-pointer"
+        onClick={() => setOpen(true)}
+      >
+        {children}
+      </a>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent className="w-[70vw]">
+          <div className="flex justify-between items-start">
+            <p>
+              The ZMK Project:{" "}
+              <ExternalLink href="https://zmk.dev/">website</ExternalLink>,{" "}
+              <ExternalLink href="https://github.com/zmkfirmware/zmk/issues/">
+                GitHub Issues
+              </ExternalLink>
+              ,{" "}
+              <ExternalLink href="https://zmk.dev/community/discord/invite">
+                Discord Server
+              </ExternalLink>
+            </p>
+          </div>
+          <div>
+            <p className="py-1 mr-2">
+              ZMK Studio is made possible thanks to the generous donation of
+              time from our contributors, as well as the financial sponsorship
+              from the following vendors:
+            </p>
+          </div>
+          <div className="grid gap-2 auto-rows-auto grid-cols-[auto_minmax(min-content,1fr)] justify-items-center items-center">
+            {sponsors.map((s) => {
+              const heightVariants = {
+                [SponsorSize.Large]: "h-16",
+                [SponsorSize.Medium]: "h-12",
+                [SponsorSize.Small]: "h-8",
+              };
 
-          return (
-            <React.Fragment key={s.level}>
-              <label>{s.level}</label>
-              <div
-                className={`grid grid-rows-1 gap-x-1 auto-cols-fr grid-flow-col justify-items-center items-center ${
-                  heightVariants[s.size]
-                }`}
-              >
-                {s.vendors.map((v) => {
-                  const maxSizeVariants = {
-                    [SponsorSize.Large]: "max-h-16",
-                    [SponsorSize.Medium]: "max-h-12",
-                    [SponsorSize.Small]: "max-h-8",
-                  };
+              return (
+                <React.Fragment key={s.level}>
+                  <label>{s.level}</label>
+                  <div
+                    className={`grid grid-rows-1 gap-x-1 auto-cols-fr grid-flow-col justify-items-center items-center ${
+                      heightVariants[s.size]
+                    }`}
+                  >
+                    {s.vendors.map((v) => {
+                      const maxSizeVariants = {
+                        [SponsorSize.Large]: "max-h-16",
+                        [SponsorSize.Medium]: "max-h-12",
+                        [SponsorSize.Small]: "max-h-8",
+                      };
 
-                  return (
-                    <a key={v.name} href={v.url} target="_blank">
-                      <picture aria-label={v.name}>
-                        {v.darkModeImg && (
-                          <source
-                            className={maxSizeVariants[s.size]}
-                            srcSet={v.darkModeImg}
-                            media="(prefers-color-scheme: dark)"
-                          />
-                        )}
-                        <img className={maxSizeVariants[s.size]} src={v.img} />
-                      </picture>
-                    </a>
-                  );
-                })}
-              </div>
-            </React.Fragment>
-          );
-        })}
-      </div>
-    </GenericModal>
+                      return (
+                        <a key={v.name} href={v.url} target="_blank">
+                          <picture aria-label={v.name}>
+                            {v.darkModeImg && (
+                              <source
+                                className={maxSizeVariants[s.size]}
+                                srcSet={v.darkModeImg}
+                                media="(prefers-color-scheme: dark)"
+                              />
+                            )}
+                            <img
+                              className={maxSizeVariants[s.size]}
+                              src={v.img}
+                            />
+                          </picture>
+                        </a>
+                      );
+                    })}
+                  </div>
+                </React.Fragment>
+              );
+            })}
+          </div>
+        </ModalContent>
+      </Modal>
+    </>
   );
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,8 +27,6 @@ import { LockStateContext } from "./rpc/LockStateContext";
 import { UnlockModal } from "./UnlockModal";
 import { valueAfter } from "./misc/async";
 import { AppFooter } from "./AppFooter";
-import { AboutModal } from "./AboutModal";
-import { LicenseNoticeModal } from "./misc/LicenseNoticeModal";
 
 declare global {
   interface Window {
@@ -166,8 +164,6 @@ function App() {
     string | undefined
   >(undefined);
   const [doIt, undo, redo, canUndo, canRedo, reset] = useUndoRedo();
-  const [showAbout, setShowAbout] = useState(false);
-  const [showLicenseNotice, setShowLicenseNotice] = useState(false);
   const [connectionAbort, setConnectionAbort] = useState(new AbortController());
 
   const [lockState, setLockState] = useState<LockState>(
@@ -290,11 +286,6 @@ function App() {
             transports={TRANSPORTS}
             onTransportCreated={onConnect}
           />
-          <AboutModal open={showAbout} onClose={() => setShowAbout(false)} />
-          <LicenseNoticeModal
-            open={showLicenseNotice}
-            onClose={() => setShowLicenseNotice(false)}
-          />
           <div className="bg-base-100 text-base-content h-full max-h-[100vh] w-full max-w-[100vw] inline-grid grid-cols-[auto] grid-rows-[auto_1fr_auto] overflow-hidden">
             <AppHeader
               connectedDeviceLabel={connectedDeviceName}
@@ -308,10 +299,7 @@ function App() {
               onResetSettings={resetSettings}
             />
             <Keyboard />
-            <AppFooter
-              onShowAbout={() => setShowAbout(true)}
-              onShowLicenseNotice={() => setShowLicenseNotice(true)}
-            />
+            <AppFooter />
           </div>
         </UndoRedoContext.Provider>
       </LockStateContext.Provider>

--- a/src/AppFooter.tsx
+++ b/src/AppFooter.tsx
@@ -1,24 +1,20 @@
-export interface AppFooterProps {
-  onShowAbout: () => void;
-  onShowLicenseNotice: () => void;
-}
+import { AboutModal } from "./AboutModal";
+import { LicenseNoticeModal } from "./misc/LicenseNoticeModal";
 
-export const AppFooter = ({
-  onShowAbout,
-  onShowLicenseNotice,
-}: AppFooterProps) => {
+export const AppFooter = () => {
   return (
-    <div className="grid justify-center p-1 bg-base-200">
-      <div>
-        <span>&copy; 2024 - The ZMK Contributors</span> -{" "}
-        <a className="hover:text-primary hover:cursor-pointer" onClick={onShowAbout}>
-          About ZMK Studio
-        </a>{" "}
-        -{" "}
-        <a className="hover:text-primary hover:cursor-pointer" onClick={onShowLicenseNotice}>
-          License NOTICE
-        </a>
+    <>
+      <div className="w-full flex justify-center gap-2 p-1 bg-base-200 relative z-50">
+        <span>&copy; 2024 - The ZMK Contributors</span>
+        <span>&ndash;</span>
+        <AboutModal>
+          <span>About ZMK Studio</span>
+        </AboutModal>
+        <span>&ndash;</span>
+        <LicenseNoticeModal>
+          <span>License NOTICE</span>
+        </LicenseNoticeModal>
       </div>
-    </div>
+    </>
   );
 };

--- a/src/AppHeader.tsx
+++ b/src/AppHeader.tsx
@@ -7,14 +7,28 @@ import {
 } from "react-aria-components";
 import { useConnectedDeviceData } from "./rpc/useConnectedDeviceData";
 import { useSub } from "./usePubSub";
-import { useContext, useEffect, useState } from "react";
-import { useModalRef } from "./misc/useModalRef";
+import {
+  Dispatch,
+  FC,
+  SetStateAction,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
 import { LockStateContext } from "./rpc/LockStateContext";
 import { LockState } from "@zmkfirmware/zmk-studio-ts-client/core";
 import { ConnectionContext } from "./rpc/ConnectionContext";
-import { ChevronDown, Undo2, Redo2, Save, Trash2 } from "lucide-react";
+import {
+  ChevronDown,
+  Undo2,
+  Redo2,
+  Save,
+  Trash2,
+  AlertTriangle,
+} from "lucide-react";
 import { Tooltip } from "./misc/Tooltip";
-import { GenericModal } from "./GenericModal";
+import { Modal, ModalContent } from "./components/modal/Modal";
 
 export interface AppHeaderProps {
   connectedDeviceLabel?: string;
@@ -27,6 +41,57 @@ export interface AppHeaderProps {
   canUndo?: boolean;
   canRedo?: boolean;
 }
+
+const RestoreSettingsPrompt: FC<
+  Pick<AppHeaderProps, "onResetSettings"> & {
+    open: boolean;
+    onOpenChange: (value: boolean) => void | Dispatch<SetStateAction<boolean>>;
+  }
+> = ({ onResetSettings, open, onOpenChange }) => {
+  const handleContinue = useCallback(() => {
+    onOpenChange(false);
+    onResetSettings?.();
+  }, [onOpenChange, onResetSettings]);
+
+  return (
+    <Modal open={open} onOpenChange={onOpenChange}>
+      <ModalContent className="relative w-96 pt-8 px-6">
+        <div className="space-y-6">
+          <div className="flex flex-row gap-2 justify-center items-center">
+            <AlertTriangle className="size-6 text-amber-500" />
+            <span className="text-lg text-base-content">
+              Restore stock settings.
+            </span>
+          </div>
+          <div className="space-y-4 text-center text-sm">
+            <p className="text-base-content tracking-wide">
+              Reset will restore the default keymap and remove all ZMK Studio
+              customizations.
+            </p>
+
+            <p className="text-base-content">
+              Are you sure you want to continue?
+            </p>
+          </div>
+          <div className="flex justify-center items-center gap-3">
+            <button
+              className="rounded bg-base-300 hover:text-base-content hover:bg-base-200 px-4 py-2 h-11 transition-colors"
+              onClick={() => onOpenChange(false)}
+            >
+              <span>Cancel</span>
+            </button>
+            <button
+              className="rounded text-white bg-red-800 hover:text-white hover:bg-red-700 px-4 py-2 h-11 transition-colors"
+              onClick={handleContinue}
+            >
+              <span>Reset Settings</span>
+            </button>
+          </div>
+        </div>
+      </ModalContent>
+    </Modal>
+  );
+};
 
 export const AppHeader = ({
   connectedDeviceLabel,
@@ -44,6 +109,8 @@ export const AppHeader = ({
   const lockState = useContext(LockStateContext);
   const connectionState = useContext(ConnectionContext);
 
+  const [promptRestoreSettings, setPromptRestoreSettings] = useState(false);
+
   useEffect(() => {
     if (
       (!connectionState.conn ||
@@ -54,14 +121,14 @@ export const AppHeader = ({
     }
   }, [lockState, showSettingsReset]);
 
-  const showSettingsRef = useModalRef(showSettingsReset);
+
   const [unsaved, setUnsaved] = useConnectedDeviceData<boolean>(
     { keymap: { checkUnsavedChanges: true } },
-    (r) => r.keymap?.checkUnsavedChanges
+    (r) => r.keymap?.checkUnsavedChanges,
   );
 
   useSub("rpc_notification.keymap.unsavedChangesStatusChanged", (unsaved) =>
-    setUnsaved(unsaved)
+    setUnsaved(unsaved),
   );
 
   return (
@@ -70,33 +137,7 @@ export const AppHeader = ({
         <img src="/zmk.svg" alt="ZMK Logo" className="h-8 rounded" />
         <p>Studio</p>
       </div>
-      <GenericModal ref={showSettingsRef} className="max-w-[50vw]">
-        <h2 className="my-2 text-lg">Restore Stock Settings</h2>
-        <div>
-          <p>
-            Settings reset will remove any customizations previously made in ZMK
-            Studio and restore the stock keymap
-          </p>
-          <p>Continue?</p>
-          <div className="flex justify-end my-2 gap-3">
-            <Button
-              className="rounded bg-base-200 hover:bg-base-300 px-3 py-2"
-              onPress={() => setShowSettingsReset(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              className="rounded bg-base-200 hover:bg-base-300 px-3 py-2"
-              onPress={() => {
-                setShowSettingsReset(false);
-                onResetSettings?.();
-              }}
-            >
-              Restore Stock Settings
-            </Button>
-          </div>
-        </div>
-      </GenericModal>
+
       <MenuTrigger>
         <Button
           className="text-center rac-disabled:opacity-0 hover:bg-base-300 transition-all duration-100 p-1 pl-2 rounded-lg"
@@ -115,7 +156,7 @@ export const AppHeader = ({
             </MenuItem>
             <MenuItem
               className="px-2 py-1 hover:bg-base-200"
-              onAction={() => setShowSettingsReset(true)}
+              onAction={() => setPromptRestoreSettings(true)}
             >
               Restore Stock Settings
             </MenuItem>
@@ -165,6 +206,12 @@ export const AppHeader = ({
           </Button>
         </Tooltip>
       </div>
+
+      <RestoreSettingsPrompt
+        open={promptRestoreSettings}
+        onOpenChange={setPromptRestoreSettings}
+        onResetSettings={onResetSettings}
+      />
     </header>
   );
 };

--- a/src/ConnectModal.tsx
+++ b/src/ConnectModal.tsx
@@ -8,7 +8,6 @@ import { Key, ListBox, ListBoxItem, Selection } from "react-aria-components";
 import { ExternalLink } from "./misc/ExternalLink";
 import { Modal, ModalContent } from "./components/modal/Modal";
 import { ZmkStudio } from "./components/ZmkStudio";
-import { AppFooter } from './AppFooter'
 
 export type TransportFactory = {
   label: string;
@@ -289,8 +288,8 @@ export const ConnectModal = ({
           ? connectOptions(transports, onTransportCreated, open)
           : noTransportsOptionsPrompt()}
 
-        <div className="text-xs opacity-40 pointer-events-none select-none">
-          <AppFooter />
+        <div className="text-xs text-center opacity-40 select-none">
+          <span>&copy; 2024 - The ZMK Contributors</span>
         </div>
       </ModalContent>
     </Modal>

--- a/src/ConnectModal.tsx
+++ b/src/ConnectModal.tsx
@@ -5,9 +5,10 @@ import { UserCancelledError } from "@zmkfirmware/zmk-studio-ts-client/transport/
 import type { AvailableDevice } from "./tauri/index";
 import { Bluetooth, RefreshCw } from "lucide-react";
 import { Key, ListBox, ListBoxItem, Selection } from "react-aria-components";
-import { useModalRef } from "./misc/useModalRef";
 import { ExternalLink } from "./misc/ExternalLink";
-import { GenericModal } from "./GenericModal";
+import { Modal, ModalContent } from "./components/modal/Modal";
+import { ZmkStudio } from "./components/ZmkStudio";
+import { AppFooter } from './AppFooter'
 
 export type TransportFactory = {
   label: string;
@@ -200,7 +201,7 @@ function simpleDevicePicker(
   return (
     <div>
       <p className="text-sm">Select a connection type.</p>
-      <ul className="flex gap-2 pt-2">{connections}</ul>
+      <ul className="flex justify-center items-center gap-2 pt-2">{connections}</ul>
       {selectedTransport && availableDevices && (
         <ul>
           {availableDevices.map((d) => (
@@ -278,16 +279,20 @@ export const ConnectModal = ({
   transports,
   onTransportCreated,
 }: ConnectModalProps) => {
-  const dialog = useModalRef(open || false, false, false);
-
   const haveTransports = useMemo(() => transports.length > 0, [transports]);
 
   return (
-    <GenericModal ref={dialog} className="max-w-xl">
-      <h1 className="text-xl">Welcome to ZMK Studio</h1>
-      {haveTransports
-        ? connectOptions(transports, onTransportCreated, open)
-        : noTransportsOptionsPrompt()}
-    </GenericModal>
+    <Modal open={open ?? true} onOpenChange={()=> {}} onEscapeClose={false} onBackdropClose={false}>
+      <ModalContent className="w-11/12 sm:w-10/12 md:w-8/12 lg:w-5/12 xl:w-4/12 mx-auto min-h-48 flex flex-col justify-between items-center gap-6 pt-8 pb-2" showCloseButton={false}>
+        <ZmkStudio />
+        {haveTransports
+          ? connectOptions(transports, onTransportCreated, open)
+          : noTransportsOptionsPrompt()}
+
+        <div className="text-xs opacity-40 pointer-events-none select-none">
+          <AppFooter />
+        </div>
+      </ModalContent>
+    </Modal>
   );
 };

--- a/src/components/ZmkStudio.tsx
+++ b/src/components/ZmkStudio.tsx
@@ -1,0 +1,71 @@
+import { FC, SVGProps, useId } from "react";
+
+const ZmkLogo: FC<SVGProps<SVGSVGElement>> = (props) => {
+  const gradientId = useId();
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 135.47 135.47"
+      {...props}
+      className={props.className ?? "size-10 rounded"}
+    >
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x2={135.5}
+          y1={-0.19}
+          y2={135.32}
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset={0} stopColor="#026fc5" />
+          <stop offset={1} stopColor="#7829d1" />
+        </linearGradient>
+      </defs>
+      <g strokeLinecap="round">
+        <path
+          fill={`url(#${gradientId})`}
+          stroke={`url(#${gradientId})`}
+          strokeLinejoin="round"
+          strokeWidth={0.15}
+          d="M0-.19h135.5v135.5H0z"
+          paintOrder="stroke markers fill"
+        />
+        <g fill="none" stroke="#fff" strokeWidth={8.76}>
+          <path
+            strokeLinejoin="round"
+            d="M53.52 85.45V48.48l14.24 18.16 14.19-18.1v37.59M15.49 48.89h22.14l-21.31 36.9h20.53m61.71-37.4V87"
+          />
+          <path
+            strokeLinejoin="bevel"
+            strokeMiterlimit={0}
+            d="m119.86 48.5-18.32 18.14 18.44 20.44"
+          />
+        </g>
+      </g>
+    </svg>
+  );
+};
+
+type ZmkStudioProps = {
+  containerClassName?: string;
+  logoProps?: SVGProps<SVGSVGElement>;
+  textClassName?: string;
+};
+
+export const ZmkStudio: FC<ZmkStudioProps> = ({
+  containerClassName,
+  logoProps,
+  textClassName,
+}) => (
+  <div
+    className={
+      containerClassName ??
+      "flex cursor-default select-none items-center justify-start gap-1.5"
+    }
+  >
+    <ZmkLogo {...logoProps} />
+    <span className={textClassName ?? "text-lg uppercase opacity-85"}>
+      Studio
+    </span>
+  </div>
+);

--- a/src/components/modal/Modal.stories.tsx
+++ b/src/components/modal/Modal.stories.tsx
@@ -3,6 +3,7 @@ import { Modal as ModalComponent, ModalContent as Content } from "./Modal";
 
 import { useState } from "react";
 import { ModalContent } from "./ModalContent.stories";
+import { ZmkStudio } from "../ZmkStudio";
 
 const meta = {
   title: "UI/Modal",
@@ -63,6 +64,7 @@ export const Modal: Story = {
           onEscapeClose={args.onEscapeClose}
         >
           <Content {...ModalContent.args}>
+            <ZmkStudio />
             <div>Hello World</div>
           </Content>
         </ModalComponent>

--- a/src/components/modal/Modal.stories.tsx
+++ b/src/components/modal/Modal.stories.tsx
@@ -48,8 +48,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Modal: Story = {
   args: {
-    onBackdropClose: false,
-    onEscapeClose: false,
+    onBackdropClose: true,
+    onEscapeClose: true,
   },
 
   render: (args) => {

--- a/src/components/modal/Modal.stories.tsx
+++ b/src/components/modal/Modal.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Modal as ModalComponent, ModalContent as Content } from "./Modal";
+
+import { useState } from "react";
+import { ModalContent } from "./ModalContent.stories";
+
+const meta = {
+  title: "UI/Modal",
+  component: ModalComponent,
+  subcomponents: {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    ModalContent: Content,
+  },
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    open: false,
+    onOpenChange: () => {},
+    onBackdropClose: false,
+    onEscapeClose: true,
+  },
+  argTypes: {
+    open: {
+      control: {
+        type: "boolean",
+      },
+    },
+    onBackdropClose: {
+      control: {
+        type: "boolean",
+      },
+    },
+    onEscapeClose: {
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+} satisfies Meta<typeof ModalComponent>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Modal: Story = {
+  args: {
+    onBackdropClose: false,
+    onEscapeClose: false,
+  },
+
+  render: (args) => {
+    const [open, setOpen] = useState(args.open);
+    return (
+      <>
+        <button onClick={() => setOpen(true)}>Open</button>
+        <ModalComponent
+          open={open}
+          onOpenChange={setOpen}
+          onBackdropClose={args.onBackdropClose}
+          onEscapeClose={args.onEscapeClose}
+        >
+          <Content {...ModalContent.args}>
+            <div>Hello World</div>
+          </Content>
+        </ModalComponent>
+      </>
+    );
+  },
+};

--- a/src/components/modal/Modal.tsx
+++ b/src/components/modal/Modal.tsx
@@ -1,0 +1,126 @@
+import { X } from "lucide-react";
+import {
+  FC,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useRef,
+  forwardRef,
+  useId,
+} from "react";
+import { ModalContext, ModalContextType } from "./ModalContext";
+
+export const Modal: FC<PropsWithChildren<Omit<ModalContextType, "id">>> = ({
+  children,
+  onEscapeClose = true,
+  onBackdropClose = true,
+  open,
+  onOpenChange,
+}) => {
+  const dialogId = useId();
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    const dialog = dialogRef.current!;
+
+    if (open) {
+      dialog.showModal();
+      requestAnimationFrame(() => {
+        dialog.dataset.open = "";
+        delete dialog.dataset.closing;
+      });
+
+      const handleEscape = (e: KeyboardEvent) => {
+        e.preventDefault();
+
+        if (!onEscapeClose) return;
+        if (e.key !== "Escape") return;
+        onOpenChange(false);
+      };
+
+      dialog.addEventListener("keydown", handleEscape);
+      return () => void dialog.removeEventListener("keydown", handleEscape);
+    } else {
+      dialog.dataset.closing = "";
+      delete dialog.dataset.open;
+
+      const backdrop = dialog.firstElementChild as HTMLElement;
+      const content = backdrop?.firstElementChild as HTMLElement;
+
+      let transitionsComplete = 0;
+
+      const handleTransitionEnd = () => {
+        // Increment counter to track when both backdrop and content transitions are complete
+        transitionsComplete++;
+
+        // If both transitions are completee the dialog
+        if (transitionsComplete >= 2) {
+          dialog.close();
+          backdrop?.removeEventListener("transitionend", handleTransitionEnd);
+          content?.removeEventListener("transitionend", handleTransitionEnd);
+        }
+      };
+
+      backdrop?.addEventListener("transitionend", handleTransitionEnd);
+      content?.addEventListener("transitionend", handleTransitionEnd);
+
+      return () => {
+        backdrop.removeEventListener("transitionend", handleTransitionEnd);
+        content?.removeEventListener("transitionend", handleTransitionEnd);
+      };
+    }
+  }, [onEscapeClose, onOpenChange, open]);
+
+  const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!onBackdropClose) return;
+    if (e.target === e.currentTarget) {
+      onOpenChange(false);
+    }
+  };
+
+  return (
+    <ModalContext.Provider value={{ id: dialogId, open, onOpenChange }}>
+      <dialog id={dialogId} ref={dialogRef} className="group">
+        <div className="fixed w-full h-full overflow-y inset-0 grid place-content-center bg-black/30 backdrop-blur-sm opacity-0 transition-all duration-300 ease-in-out group-data-[open]:opacity-100 group-data-[closing]:opacity-0">
+          <div
+            className="overflow-y-auto w-screen h-screen place-content-center scale-75 py-10 opacity-0 shadow-lg transition-all duration-300 ease-out group-data-[open]:scale-100 group-data-[open]:opacity-100 group-data-[closing]:scale-75 group-data-[closing]:opacity-0"
+            onClick={handleBackdropClick}
+          >
+            {children}
+          </div>
+        </div>
+      </dialog>
+    </ModalContext.Provider>
+  );
+};
+
+type ModalContentProps = PropsWithChildren<{
+  className?: string;
+  showCloseButton?: boolean;
+}>;
+
+export const ModalContent = forwardRef<HTMLDivElement, ModalContentProps>(
+  function ModalContent({ children, className, showCloseButton = true }, ref) {
+    const { onOpenChange } = useContext(ModalContext);
+    return (
+      <div
+        ref={ref}
+        className={[
+          "relative m-auto rounded-lg bg-base-100 text-base-content min-w-96 p-4 space-y-4",
+          className,
+        ].join(" ")}
+      >
+        {children}
+        {showCloseButton && (
+          <button
+            className="absolute top-2.5 right-4 text-base-content opacity-50 hover:opacity-100 transition-opacity duration-300"
+            onClick={() => onOpenChange(false)}
+          >
+            <span className="sr-only">Close</span>
+            <X className="size-4" />
+          </button>
+        )}
+      </div>
+    );
+  },
+);

--- a/src/components/modal/ModalContent.stories.tsx
+++ b/src/components/modal/ModalContent.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Modal as ModalComponent, ModalContent as Content } from "./Modal";
+
+const meta = {
+  title: "UI/Modal/ModalContent",
+  component: Content,
+  parameters: {
+    layout: "centered",
+  },
+  tags: [],
+  args: {
+    showCloseButton: true,
+    className: "max-w-2xl min-h-48",
+  },
+  argTypes: {
+    className: {
+      control: {
+        type: "text",
+      },
+    },
+    showCloseButton: {
+      defaultValue: true,
+      control: {
+        type: "boolean",
+      },
+    },
+  },
+} satisfies Meta<typeof Content>;
+
+export default meta;
+type ModalContentStory = StoryObj<typeof meta>;
+
+export const ModalContent: ModalContentStory = {
+  args: {
+    showCloseButton: true,
+    className: "max-w-2xl min-h-48",
+  },
+  render: (args) => (
+    <ModalComponent open={true} onOpenChange={() => {}}>
+      <Content {...args}>Hello</Content>
+    </ModalComponent>
+  ),
+};

--- a/src/components/modal/ModalContent.stories.tsx
+++ b/src/components/modal/ModalContent.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Modal as ModalComponent, ModalContent as Content } from "./Modal";
+import { ZmkStudio } from "../ZmkStudio";
 
 const meta = {
   title: "UI/Modal/ModalContent",
@@ -37,7 +38,10 @@ export const ModalContent: ModalContentStory = {
   },
   render: (args) => (
     <ModalComponent open={true} onOpenChange={() => {}}>
-      <Content {...args}>Hello</Content>
+      <Content {...args}>
+        <ZmkStudio />
+        <div>Hello World</div>
+      </Content>
     </ModalComponent>
   ),
 };

--- a/src/components/modal/ModalContext.tsx
+++ b/src/components/modal/ModalContext.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Dispatch, PropsWithChildren, SetStateAction } from "react";
+
+export type ModalContextType = PropsWithChildren<{
+  id: string;
+  open: boolean;
+  onEscapeClose?: boolean;
+  onBackdropClose?: boolean;
+  onOpenChange: (open: boolean) => void | Dispatch<SetStateAction<boolean>>;
+}>;
+
+export const ModalContext = React.createContext<ModalContextType>(
+  {} as ModalContextType,
+);

--- a/src/components/modal/useModalRef.tsx
+++ b/src/components/modal/useModalRef.tsx
@@ -1,0 +1,6 @@
+import { ModalContext, ModalContextType } from "./ModalContext";
+import { useContext } from "react";
+
+export function useModalRef(): ModalContextType {
+  return useContext(ModalContext);
+}

--- a/src/keyboard/LayerPicker.tsx
+++ b/src/keyboard/LayerPicker.tsx
@@ -8,8 +8,7 @@ import {
   Selection,
   useDragAndDrop,
 } from "react-aria-components";
-import { useModalRef } from "../misc/useModalRef";
-import { GenericModal } from "../GenericModal";
+import { Modal, ModalContent } from "../components/modal/Modal.tsx";
 
 interface Layer {
   id: number;
@@ -49,56 +48,62 @@ const EditLabelModal = ({
 }: {
   open: boolean;
   onClose: () => void;
-  editLabelData: EditLabelData;
+  editLabelData: EditLabelData | null;
   handleSaveNewLabel: (
     id: number,
     oldName: string,
     newName: string | null
   ) => void;
 }) => {
-  const ref = useModalRef(open);
-  const [newLabelName, setNewLabelName] = useState(editLabelData.name);
+  const [newLabelName, setNewLabelName] = useState(editLabelData?.name ?? '');
 
-  const handleSave = () => {
+  const handleSave = useCallback(() => {
+    if (!editLabelData) return 
+    
     handleSaveNewLabel(editLabelData.id, editLabelData.name, newLabelName);
     onClose();
-  };
+  }, [editLabelData]);
 
   return (
-    <GenericModal
-      ref={ref}
-      onClose={onClose}
-      className="min-w-min w-[30vw] flex flex-col"
-    >
-      <span className="mb-3 text-lg">New Layer Name</span>
-      <input
-        className="p-1 border rounded border-base-content border-solid"
-        type="text"
-        defaultValue={editLabelData.name}
-        autoFocus
-        onChange={(e) => setNewLabelName(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            handleSave();
-          }
-        }}
-      />
-      <div className="mt-4 flex justify-end">
-        <button className="py-1.5 px-2" type="button" onClick={onClose}>
-          Cancel
-        </button>
-        <button
-          className="py-1.5 px-2 ml-4 rounded-md bg-gray-100 text-black hover:bg-gray-300"
-          type="button"
-          onClick={() => {
-            handleSave();
-          }}
-        >
-          Save
-        </button>
-      </div>
-    </GenericModal>
+    <Modal open={open} onOpenChange={onClose}>
+      <ModalContent
+        className="min-w-min w-[30vw] flex flex-col"
+      >
+        {editLabelData && (
+          <>
+            <span className="mb-3 text-lg">New Layer Name</span>
+            <input
+              className="p-1 border rounded border-base-content border-solid"
+              type="text"
+              defaultValue={editLabelData.name}
+              autoFocus
+              onChange={(e) => setNewLabelName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleSave();
+                }
+              }}
+            />
+            <div className="mt-4 flex justify-end">
+              <button className="py-1.5 px-2" type="button" onClick={onClose}>
+                Cancel
+              </button>
+              <button
+                className="py-1.5 px-2 ml-4 rounded-md bg-gray-100 text-black hover:bg-gray-300"
+                type="button"
+                disabled={!!editLabelData}
+                onClick={() => {
+                  handleSave();
+                }}
+              >
+                Save
+              </button>
+            </div>
+          </>
+        )}
+      </ModalContent>
+    </Modal>
   );
 };
 
@@ -190,14 +195,14 @@ export const LayerPicker = ({
           </button>
         )}
       </div>
-      {editLabelData !== null && (
-        <EditLabelModal
-          open={editLabelData !== null}
-          onClose={() => setEditLabelData(null)}
-          editLabelData={editLabelData}
-          handleSaveNewLabel={handleSaveNewLabel}
-        />
-      )}
+
+      <EditLabelModal
+        open={!!editLabelData}
+        onClose={() => setEditLabelData(null)}
+        editLabelData={editLabelData}
+        handleSaveNewLabel={handleSaveNewLabel}
+      />
+    
       <ListBox
         aria-label="Keymap Layer"
         selectionMode="single"

--- a/src/misc/LicenseNoticeModal.tsx
+++ b/src/misc/LicenseNoticeModal.tsx
@@ -14,7 +14,7 @@ export const LicenseNoticeModal: FC<PropsWithChildren> = ({ children }) => {
         {children}
       </a>
       <Modal open={open} onOpenChange={setOpen}>
-        <ModalContent className="w-[40vw]">
+        <ModalContent className="w-9/12 md:max-w-3xl">
           <div className="flex justify-between items-start">
             <p className="mr-2">
               ZMK Studio is released under the open source Apache 2.0 license. A
@@ -22,7 +22,7 @@ export const LicenseNoticeModal: FC<PropsWithChildren> = ({ children }) => {
               here:
             </p>
           </div>
-          <pre className="w-96 m-4 font-mono text-xs">{NOTICE}</pre>
+          <pre className="w-full overflow-auto font-mono text-xs p-3 border border-base-300 rounded-lg bg-base-200">{NOTICE}</pre>
         </ModalContent>
       </Modal>
     </>

--- a/src/misc/LicenseNoticeModal.tsx
+++ b/src/misc/LicenseNoticeModal.tsx
@@ -1,41 +1,30 @@
-import { useModalRef } from "./useModalRef";
-
+import { FC, PropsWithChildren, useState } from "react";
 import NOTICE from "../../NOTICE?raw";
-import { GenericModal } from "../GenericModal";
+import { Modal, ModalContent } from "../components/modal/Modal";
 
-export interface LicenseNoticeModalProps {
-  open: boolean;
-  onClose: () => void;
-}
-
-export const LicenseNoticeModal = ({
-  open,
-  onClose,
-}: LicenseNoticeModalProps) => {
-  const ref = useModalRef(open, true);
-
+export const LicenseNoticeModal: FC<PropsWithChildren> = ({ children }) => {
+  const [open, setOpen] = useState(false);
   return (
-    <GenericModal
-      ref={ref}
-      className="min-w-min w-[60vw]"
-      onClose={onClose}
-    >
-      <div>
-        <div className="flex justify-between items-start">
-          <p className="mr-2">
-            ZMK Studio is released under the open source Apache 2.0 license. A
-            copy of the NOTICE file from the ZMK Studio repository is included
-            here:
-          </p>
-          <button
-            className="p-1.5 rounded-md bg-gray-100 text-black hover:bg-gray-300"
-            onClick={onClose}
-          >
-            Close
-          </button>
-        </div>
-        <pre className="m-4 font-mono text-xs">{NOTICE}</pre>
-      </div>
-    </GenericModal>
+    <>
+      <a
+        role="button"
+        className="hover:text-primary hover:cursor-pointer"
+        onClick={() => setOpen(true)}
+      >
+        {children}
+      </a>
+      <Modal open={open} onOpenChange={setOpen}>
+        <ModalContent className="w-[40vw]">
+          <div className="flex justify-between items-start">
+            <p className="mr-2">
+              ZMK Studio is released under the open source Apache 2.0 license. A
+              copy of the NOTICE file from the ZMK Studio repository is included
+              here:
+            </p>
+          </div>
+          <pre className="w-96 m-4 font-mono text-xs">{NOTICE}</pre>
+        </ModalContent>
+      </Modal>
+    </>
   );
 };


### PR DESCRIPTION
- feat: improve modal transition on open/close event
  - added: modal stories
- feat: generic zmk-logo for use on modals (or anywhere in the app)
- updated: migrated sections that utilizes `GenericModal` 
  - moved: `useModalRef` -> `@/components/modal/useModalRef`
  - removed: `GenericModal`


