### PR TITLE
Support token auth on release fetch

### DIFF
--- a/scripts/generate-release-data.js
+++ b/scripts/generate-release-data.js
@@ -9,13 +9,23 @@ async function generateReleaseData() {
   try {
     const response = await fetch(
       "https://api.github.com/repos/zmkfirmware/zmk-studio/releases/latest",
+      {
+        headers: process.env.GITHUB_TOKEN
+          ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` }
+          : {},
+      },
     );
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
     const data = await response.json();
-    const dataFilePath = path.resolve(__dirname, "src", "data", "release-data.json");
+    const dataFilePath = path.resolve(
+      __dirname,
+      "src",
+      "data",
+      "release-data.json",
+    );
     await fs.mkdir(path.dirname(dataFilePath), { recursive: true });
     await fs.writeFile(dataFilePath, JSON.stringify(data));
 


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix(ci): Support token auth on release fetch (#126)

Fix builds by authenticating our fetch of the releases from the GH API.
END_COMMIT_OVERRIDE