### PR TITLE
fix: keys not rerendering between layers

### DIFF
--- a/src/keyboard/Keymap.tsx
+++ b/src/keyboard/Keymap.tsx
@@ -38,7 +38,7 @@ export const Keymap = ({
   const positions = layout.keys.map((k, i) => {
     if (i >= keymap.layers[selectedLayerIndex].bindings.length) {
       return {
-        id: `${keymap.layers[selectedLayerIndex].name}-${i}`,
+        id: `${keymap.layers[selectedLayerIndex].id}-${i}`,
         header: "Unknown",
         x: k.x / 100.0,
         y: k.y / 100.0,
@@ -49,7 +49,7 @@ export const Keymap = ({
     }
 
     return {
-      id: `${keymap.layers[selectedLayerIndex].name}-${i}`,
+      id: `${keymap.layers[selectedLayerIndex].id}-${i}`,
       header:
         behaviors[keymap.layers[selectedLayerIndex].bindings[i].behaviorId]
           ?.displayName || "Unknown",

--- a/src/keyboard/Keymap.tsx
+++ b/src/keyboard/Keymap.tsx
@@ -35,9 +35,10 @@ export const Keymap = ({
     return <></>;
   }
 
-  let positions = layout.keys.map((k, i) => {
+  const positions = layout.keys.map((k, i) => {
     if (i >= keymap.layers[selectedLayerIndex].bindings.length) {
       return {
+        id: `${keymap.layers[selectedLayerIndex].name}-${i}`,
         header: "Unknown",
         x: k.x / 100.0,
         y: k.y / 100.0,
@@ -48,6 +49,7 @@ export const Keymap = ({
     }
 
     return {
+      id: `${keymap.layers[selectedLayerIndex].name}-${i}`,
       header:
         behaviors[keymap.layers[selectedLayerIndex].bindings[i].behaviorId]
           ?.displayName || "Unknown",

--- a/src/keyboard/PhysicalLayout.stories.tsx
+++ b/src/keyboard/PhysicalLayout.stories.tsx
@@ -173,17 +173,19 @@ const MINIVAN_POSITIONS = [
     children: [<HidUsageLabel hid_usage={hid_usage_from_page_and_id(7, 79)} />],
   },
 ];
+const POSITIONS = MINIVAN_POSITIONS.map((k, i) => ({ ...k, id: `base-${i}` }));
 
 export const Minivan: Story = {
   args: {
-    positions: MINIVAN_POSITIONS,
+    positions: POSITIONS,
     hoverZoom: true,
   },
 };
 
 export const MiniMinivan: Story = {
   args: {
-    positions: MINIVAN_POSITIONS.map(({ x, y, width, height }) => ({
+    positions: POSITIONS.map(({ id, x, y, width, height }) => ({
+      id,
       x,
       y,
       width,

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -48,14 +48,14 @@ function scalePosition(
   { x, y, r, rx, ry }: PhysicalLayoutPositionLocation,
   oneU: number,
 ): CSSProperties {
-  let left = x * oneU;
-  let top = y * oneU;
+  const left = x * oneU;
+  const top = y * oneU;
   let transformOrigin = undefined;
   let transform = undefined;
 
   if (r) {
-    let transformX = ((rx || x) - x) * oneU;
-    let transformY = ((ry || y) - y) * oneU;
+    const transformX = ((rx || x) - x) * oneU;
+    const transformY = ((ry || y) - y) * oneU;
     transformOrigin = `${transformX}px ${transformY}px`;
     transform = `rotate(${r}deg)`;
   }
@@ -115,16 +115,16 @@ export const PhysicalLayout = ({
   }, [props.zoom]);
 
   // TODO: Add a bit of padding for rotation when supported
-  let rightMost = positions
+  const rightMost = positions
     .map((k) => k.x + k.width)
     .reduce((a, b) => Math.max(a, b), 0);
-  let bottomMost = positions
+  const bottomMost = positions
     .map((k) => k.y + k.height)
     .reduce((a, b) => Math.max(a, b), 0);
 
   const positionItems = positions.map((p, idx) => (
     <div
-      key={idx}
+      key={`${p.header}${idx}`}
       onClick={() => onPositionClicked?.(idx)}
       className="absolute data-[zoomer=true]:hover:z-[1000] leading-[0]"
       data-zoomer={hoverZoom}

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -8,6 +8,7 @@ import {
 import { Key } from "./Key";
 
 export type KeyPosition = PropsWithChildren<{
+  id: string;
   header?: string;
   width: number;
   height: number;
@@ -124,7 +125,7 @@ export const PhysicalLayout = ({
 
   const positionItems = positions.map((p, idx) => (
     <div
-      key={idx}
+      key={p.id}
       onClick={() => onPositionClicked?.(idx)}
       className="absolute data-[zoomer=true]:hover:z-[1000] leading-[0]"
       data-zoomer={hoverZoom}

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -48,14 +48,14 @@ function scalePosition(
   { x, y, r, rx, ry }: PhysicalLayoutPositionLocation,
   oneU: number,
 ): CSSProperties {
-  const left = x * oneU;
-  const top = y * oneU;
+  let left = x * oneU;
+  let top = y * oneU;
   let transformOrigin = undefined;
   let transform = undefined;
 
   if (r) {
-    const transformX = ((rx || x) - x) * oneU;
-    const transformY = ((ry || y) - y) * oneU;
+    let transformX = ((rx || x) - x) * oneU;
+    let transformY = ((ry || y) - y) * oneU;
     transformOrigin = `${transformX}px ${transformY}px`;
     transform = `rotate(${r}deg)`;
   }
@@ -115,16 +115,16 @@ export const PhysicalLayout = ({
   }, [props.zoom]);
 
   // TODO: Add a bit of padding for rotation when supported
-  const rightMost = positions
+  let rightMost = positions
     .map((k) => k.x + k.width)
     .reduce((a, b) => Math.max(a, b), 0);
-  const bottomMost = positions
+  let bottomMost = positions
     .map((k) => k.y + k.height)
     .reduce((a, b) => Math.max(a, b), 0);
 
   const positionItems = positions.map((p, idx) => (
     <div
-      key={`${p.header}${idx}`}
+      key={idx}
       onClick={() => onPositionClicked?.(idx)}
       className="absolute data-[zoomer=true]:hover:z-[1000] leading-[0]"
       data-zoomer={hoverZoom}

--- a/src/keyboard/PhysicalLayoutPicker.tsx
+++ b/src/keyboard/PhysicalLayoutPicker.tsx
@@ -14,7 +14,7 @@ import { useCallback } from "react";
 
 export interface PhysicalLayoutItem {
   name: string;
-  keys: Array<KeyPosition>;
+  keys: Array<Omit<KeyPosition, "id">>;
 }
 
 export type PhysicalLayoutClickCallback = (index: number) => void;
@@ -32,11 +32,11 @@ export const PhysicalLayoutPicker = ({
   selectedPhysicalLayoutIndex,
   onPhysicalLayoutClicked,
 }: PhysicalLayoutPickerProps) => {
-  let selectionChanged = useCallback(
+  const selectionChanged = useCallback(
     (e: Key) => {
       onPhysicalLayoutClicked?.(layouts.findIndex((l) => l.name === e));
     },
-    [layouts, onPhysicalLayoutClicked]
+    [layouts, onPhysicalLayoutClicked],
   );
 
   return (
@@ -67,7 +67,8 @@ export const PhysicalLayoutPicker = ({
                   oneU={15}
                   hoverZoom={false}
                   positions={l.keys.map(
-                    ({ x, y, width, height, r, rx, ry }) => ({
+                    ({ x, y, width, height, r, rx, ry }, i) => ({
+                      id: `${layouts[selectedPhysicalLayoutIndex].name}-${i}`,
                       x: x / 100.0,
                       y: y / 100.0,
                       width: width / 100.0,
@@ -75,7 +76,7 @@ export const PhysicalLayoutPicker = ({
                       r: (r || 0) / 100.0,
                       rx: (rx || 0) / 100.0,
                       ry: (ry || 0) / 100.0,
-                    })
+                    }),
                   )}
                 />
               </div>


### PR DESCRIPTION
# The Problem
[On discord](https://discord.com/channels/719497620560543766/722441502948851741/1350095199593824360) someone reported a UI bug where keys don't change back between letters.

I wasn't able to replicate locally on tauri, but was able to see the same bug on `main`

Edit: The Issue can also be see on [zmk.studio](zmk.studio)

Video example:

https://github.com/user-attachments/assets/7e93d607-f8b2-4f3b-8226-d3c439a01198

# The Fix
It appears the issue sprouted from a place where a map index is being used for the react `key`. In general index should be avoided (see the [pitfall here](https://react.dev/learn/rendering-lists#why-does-react-need-keys)). Basically, by the key not changing between renders react skips over rerenders during reconciliation.

Video after fix:

https://github.com/user-attachments/assets/4b54f3b1-5ca8-4c42-834a-8b8de8af2bc5

## Callouts & caveats (edited)
After feedback I modified the key to be slightly less friable. The new implementation just takes in a general string `id` as part of `KeyPosition`. It's not tightly scoped to be agnostic of usage (layer vs layout, etc).

I also scoped changes to the `zmk-studio` side of the code, so we just add the `id` in [PhysicalLayoutPicker](https://github.com/zmkfirmware/zmk-studio/pull/132/files#diff-fc1a51997e206699f0c9ef9533040c91ad97a100f5b2ec8f4badd1364f4c87f8R70-R71). I debated on massaging the data in `useLayout` or `zmk-studio-ts-client` but it made more sense it keep on this side.

> [!NOTE]
> I reverted the previous work - typically I find this easiest to keep the commit history cleaner, in my own work I usually just squash merge/rebase and remove the revert & the commit it targets completely. But curious what you'd prefer 