### PR TITLE
Simplify and optimize key layout and animations

### DIFF
--- a/src/keyboard/Key.tsx
+++ b/src/keyboard/Key.tsx
@@ -1,88 +1,38 @@
-// import './key.css';
-
-import { PropsWithChildren, Children, CSSProperties } from "react";
+import { PropsWithChildren } from "react";
 
 interface KeyProps {
-  /**
-   * Is this the principal call to action on the page?
-   */
   selected?: boolean;
-  /**
-   * How large should the button be?
-   */
   width: number;
   height: number;
-
   oneU: number;
-
-  hoverZoom?: boolean;
-  /**
-   * Button contents
-   */
   header?: string;
-  /**
-   * Optional click handler
-   */
   onClick?: () => void;
-}
-
-interface KeyDimension {
-  width: number;
-  height: number;
-}
-
-function makeSize(
-  { width, height }: KeyDimension,
-  oneU: number
-): CSSProperties {
-  width *= oneU;
-  height *= oneU;
-
-  return {
-    "--zmk-key-center-width": "calc(" + width + "px - 2px)",
-    "--zmk-key-center-height": "calc(" + height + "px - 2px)",
-  };
 }
 
 export const Key = ({
   selected = false,
-  header,
+  width,
+  height,
   oneU,
-  hoverZoom = true,
-  ...props
+  header,
+  onClick,
+  children,
 }: PropsWithChildren<KeyProps>) => {
-  const size = makeSize(props, oneU);
-
-  const children = Children.map(props.children, (c) => (
-    <div
-      data-zoomer={hoverZoom}
-      className="justify-self-center self-center row-start-2 row-end-3 col-start-2 col-end-3 font-keycap text-lg data-[zoomer=true]:group-hover:text-2xl"
-    >
-      {c}
-    </div>
-  ));
+  const pixelWidth = width * oneU - 2;
+  const pixelHeight = height * oneU - 2;
 
   return (
     <div
-      className="group inline-flex b-0 justify-content-center items-center transition-all duration-100 data-[zoomer=true]:hover:translate-y-[calc(-1em-7px)] data-[zoomer=true]:hover:translate-x-[calc(-1em)]"
-      data-zoomer={hoverZoom}
-      style={size}
-      {...props}
+      className={`group rounded relative flex justify-center items-center cursor-pointer transition-all hover:shadow-xl hover:ring-1 hover:ring-black/5 hover:scale-125 ${selected ? "bg-primary text-primary-content" : "bg-base-100 text-base-content"
+        }`}
+      style={{
+        width: `${pixelWidth}px`,
+        height: `${pixelHeight}px`,
+      }}
+      onClick={onClick}
     >
-      <button
-        aria-selected={selected}
-        data-zoomer={hoverZoom}
-        className={`rounded${
-          oneU > 20 ? "-md" : ""
-        } transition-all duration-100 m-auto p-0 b-0 box-border grid grid-rows-[0_var(--zmk-key-center-height)_0] grid-cols-[0_var(--zmk-key-center-width)_0] data-[zoomer=true]:hover:grid-rows-[1em_var(--zmk-key-center-height)_1em] data-[zoomer=true]:hover:grid-cols-[1em_var(--zmk-key-center-width)_1em] shadow-[0_0_0_1px_inset] shadow-base-content data-[zoomer=true]:shadow-base-200 data-[zoomer=true]:hover:shadow-base-content data-[zoomer=true]:hover:z-50 text-base-content bg-base-100 aria-selected:bg-primary aria-selected:text-primary-content grow @container`}
-      >
-        {header && (
-          <span className="p-0 b-0 m-0 text-xs w-full h-full text-nowrap justify-self-start row-start-1 row-end-2 col-start-1 col-end-4 hidden group-hover:inline-block group-hover:truncate @md:underline">
-            {header}
-          </span>
-        )}
-        {children}
-      </button>
+      <div className={`absolute text-xs ${selected ? "text-primary-content" : "z1text-base-content"} opacity-0 group-hover:opacity-80 top-1 text-nowrap left-1/2 font-light -translate-x-1/2 text-center transition-opacity`}>{header}</div>
+      {children}
     </div>
   );
 };

--- a/src/keyboard/Key.tsx
+++ b/src/keyboard/Key.tsx
@@ -23,7 +23,7 @@ export const Key = ({
 
   return (
     <button
-      className={`group rounded relative flex justify-center items-center cursor-pointer transition-all hover:shadow-xl hover:ring-1 hover:ring-black/5 hover:scale-125 ${selected ? "bg-primary text-primary-content" : "bg-base-100 text-base-content"
+      className={`group rounded relative flex justify-center items-center cursor-pointer transition-all hover:shadow-xl hover:ring-1 hover:ring-gray-300 hover:scale-125 ${selected ? "bg-primary text-primary-content" : "bg-base-100 text-base-content"
         }`}
       style={{
         width: `${pixelWidth}px`,

--- a/src/keyboard/Key.tsx
+++ b/src/keyboard/Key.tsx
@@ -22,7 +22,7 @@ export const Key = ({
   const pixelHeight = height * oneU - 2;
 
   return (
-    <div
+    <button
       className={`group rounded relative flex justify-center items-center cursor-pointer transition-all hover:shadow-xl hover:ring-1 hover:ring-black/5 hover:scale-125 ${selected ? "bg-primary text-primary-content" : "bg-base-100 text-base-content"
         }`}
       style={{
@@ -33,6 +33,6 @@ export const Key = ({
     >
       <div className={`absolute text-xs ${selected ? "text-primary-content" : "z1text-base-content"} opacity-0 group-hover:opacity-80 top-1 text-nowrap left-1/2 font-light -translate-x-1/2 text-center transition-opacity`}>{header}</div>
       {children}
-    </div>
+    </button>
   );
 };

--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -53,6 +53,7 @@ function scalePosition(
   let top = y * oneU;
   let transformOrigin = undefined;
   let transform = undefined;
+  const transformStyle = "preserve-3d";
 
   if (r) {
     let transformX = ((rx || x) - x) * oneU;
@@ -66,7 +67,7 @@ function scalePosition(
     left,
     transformOrigin,
     transform,
-    willChange: "transform",
+    transformStyle,
   };
 }
 
@@ -74,7 +75,6 @@ export const PhysicalLayout = ({
   positions,
   selectedPosition,
   oneU = 48,
-  hoverZoom = true,
   onPositionClicked,
   ...props
 }: PhysicalLayoutProps) => {
@@ -124,19 +124,18 @@ export const PhysicalLayout = ({
     .reduce((a, b) => Math.max(a, b), 0);
 
   const positionItems = positions.map((p, idx) => (
-    <div
-      key={p.id}
-      onClick={() => onPositionClicked?.(idx)}
-      className="absolute data-[zoomer=true]:hover:z-[1000] leading-[0]"
-      data-zoomer={hoverZoom}
-      style={scalePosition(p, oneU)}
-    >
-      <Key
-        hoverZoom={hoverZoom}
-        oneU={oneU}
-        selected={idx === selectedPosition}
-        {...p}
-      />
+    <div className="absolute" style={scalePosition(p, oneU)}>
+      <div
+        key={p.id}
+        onClick={() => onPositionClicked?.(idx)}
+        className="hover:[transform:translateZ(100px)] transition-transform duration-200"
+      >
+        <Key
+          oneU={oneU}
+          selected={idx === selectedPosition}
+          {...p}
+        />
+      </div>
     </div>
   ));
 
@@ -147,6 +146,7 @@ export const PhysicalLayout = ({
         height: bottomMost * oneU + "px",
         width: rightMost * oneU + "px",
         transform: `scale(${scale})`,
+        transformStyle: "preserve-3d",
       }}
       ref={ref}
       {...props}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,9 @@ import contQueries from "@tailwindcss/container-queries";
 export default {
   content: ["./index.html", "./download.html", "./src/**/*.{js,ts,jsx,tsx}"],
   theme: {
+    fontSize: {
+      xs: "0.4rem",
+    },
     extend: {
       fontFamily: {
         sans: ["Inter", "system-ui"],


### PR DESCRIPTION
The animations when hovering a key were a bit janky, with the header popping in when hovering. The z-index used to place a key above the other keys is also not an animatable property which resulted in some flickering when hovering, so it has been replaced with translateZ.

I have removed references to `data-zoomer`, since I could not find any usage of it.

There was some iteration of `Children` in the Key.tsx, but couldnt find any cases of it actually being used. I have future plans for rendering hold tap modifiers on the key, based on some graphics from the discord channel, so I'm gonna add it back.

Finally I have removed some css calc classes that were a bit hard to understand. Whatever purpose they had, I will fix again, but try to extract the logic behind to a more readable format.

I'm sorry about removing some functionality that people have spent time on, but I feel like a refactor of some of the rendering logic is needed.

![image](https://github.com/user-attachments/assets/dde00a4c-620d-437d-9353-ab055d44ad4d)
