### PR TITLE
Define icons in HID usage name overrides file and use them when rendering key

### DIFF
--- a/src/hid-usage-name-overrides.json
+++ b/src/hid-usage-name-overrides.json
@@ -1,85 +1,305 @@
 {
   "7": {
-    "30": { "short": "1" },
-    "31": { "short": "2" },
-    "32": { "short": "3" },
-    "33": { "short": "4" },
-    "34": { "short": "5" },
-    "35": { "short": "6" },
-    "36": { "short": "7" },
-    "37": { "short": "8" },
-    "38": { "short": "9" },
-    "39": { "short": "0" },
-    "40": { "short": "Ret", "med": "Return" },
-    "41": { "short": "Esc", "long": "Escape" },
-    "42": { "short": "BkSp", "med": "BkSpc", "long": "Backspace" },
-    "44": { "short": "␣", "med": "Space" },
-    "45": { "short": "-", "med": "Dash" },
-    "46": { "short": "=", "med": "Equals" },
-    "47": { "short": "{" },
-    "48": { "short": "}" },
-    "49": { "short": "\\" },
-    "50": { "short": "NUHS", "long": "NonUS Hash" },
-    "51": { "short": ";" },
-    "52": { "short": "'" },
-    "53": { "short": "`" },
-    "54": { "short": "," },
-    "55": { "short": "." },
-    "56": { "short": "/" },
-    "57": { "short": "Cap", "long": "Caps Lock" },
-    "70": { "short": "PrSc", "long": "Print Scr" },
-    "71": { "short": "ScLk", "long": "ScrollLock" },
-    "72": { "short": "Paus", "med": "Pause" },
-    "73": { "short": "Ins", "med": "Insert" },
-    "75": { "short": "PgUp", "med": "PageUp", "long": "Page Up" },
-    "76": { "short": "Del", "med": "Delete" },
-    "78": { "short": "PgDn", "med": "PageDn", "long": "Page Down" },
-    "79": { "short": "→" },
-    "80": { "short": "←" },
-    "81": { "short": "↓" },
-    "82": { "short": "↑" },
-    "83": { "short": "Num", "med": "NumLck", "long": "Num Lock" },
-    "84": { "short": "/" },
-    "85": { "short": "*" },
-    "86": { "short": "-" },
-    "87": { "short": "+" },
-    "88": { "short": "Ent", "med": "KP Ent", "long": "KP Enter" },
-    "89": { "short": "1 En", "med": "1 End" },
-    "90": { "short": "2 ↓" },
-    "91": { "short": "3 PD", "med": "3 PgDn" },
-    "92": { "short": "4 ←" },
-    "93": { "short": "5" },
-    "94": { "short": "6 →" },
-    "95": { "short": "7 Hm", "med": "7 Home" },
-    "96": { "short": "8 ↑" },
-    "97": { "short": "9 PU", "med": "9 PgUp" },
-    "98": { "short": "0 In", "med": "0 Ins", "long": "0 Insert" },
-    "99": { "short": ". Dl", "med": ". Del", "long": ". Delete" },
-    "101": { "short": "Appl", "med": "Appl", "long": "Applicat'n" },
-    "102": { "short": "Power", "med": "Power" },
-    "100": { "short": "NUBS" },
-    "103": { "short": "=" },
-    "133": { "short": "," },
-    "134": { "short": "=" },
-    "176": { "short": "00" },
-    "177": { "short": "000" },
-    "224": { "short": "Ctrl", "med": "L Ctrl" },
-    "225": { "short": "Shft", "med": "L Shft", "long": "L Shift" },
-    "226": { "short": "Alt", "med": "L Alt", "long": "Left Alt" },
-    "227": { "short": "GUI", "med": "L GUI", "long": "Left GUI" },
-    "228": { "short": "Ctrl", "med": "R Ctrl" },
-    "229": { "short": "Shft", "med": "R Shft", "long": "R Shift" },
-    "230": { "short": "AltG", "med": "AltGr" },
-    "231": { "short": "GUI", "med": "R GUI", "long": "Right GUI" }
+    "30": {
+      "short": "1"
+    },
+    "31": {
+      "short": "2"
+    },
+    "32": {
+      "short": "3"
+    },
+    "33": {
+      "short": "4"
+    },
+    "34": {
+      "short": "5"
+    },
+    "35": {
+      "short": "6"
+    },
+    "36": {
+      "short": "7"
+    },
+    "37": {
+      "short": "8"
+    },
+    "38": {
+      "short": "9"
+    },
+    "39": {
+      "short": "0"
+    },
+    "40": {
+      "short": "Ret",
+      "med": "Return",
+      "icon": "corner-down-left"
+    },
+    "41": {
+      "short": "Esc",
+      "long": "Escape"
+    },
+    "42": {
+      "short": "BkSp",
+      "med": "BkSpc",
+      "long": "Backspace"
+    },
+    "43": {
+      "short": "Tab",
+      "icon": "arrow-right-to-line"
+    },
+    "44": {
+      "short": "␣",
+      "med": "Space"
+    },
+    "45": {
+      "short": "-",
+      "med": "Dash"
+    },
+    "46": {
+      "short": "=",
+      "med": "Equals"
+    },
+    "47": {
+      "short": "{"
+    },
+    "48": {
+      "short": "}"
+    },
+    "49": {
+      "short": "\\"
+    },
+    "50": {
+      "short": "NUHS",
+      "long": "NonUS Hash"
+    },
+    "51": {
+      "short": ";"
+    },
+    "52": {
+      "short": "'"
+    },
+    "53": {
+      "short": "`"
+    },
+    "54": {
+      "short": ","
+    },
+    "55": {
+      "short": "."
+    },
+    "56": {
+      "short": "/"
+    },
+    "57": {
+      "short": "Cap",
+      "long": "Caps Lock"
+    },
+    "70": {
+      "short": "PrSc",
+      "long": "Print Scr"
+    },
+    "71": {
+      "short": "ScLk",
+      "long": "ScrollLock"
+    },
+    "72": {
+      "short": "Paus",
+      "med": "Pause"
+    },
+    "73": {
+      "short": "Ins",
+      "med": "Insert"
+    },
+    "75": {
+      "short": "PgUp",
+      "med": "PageUp",
+      "long": "Page Up"
+    },
+    "76": {
+      "short": "Del",
+      "med": "Delete",
+      "icon": "delete"
+    },
+    "78": {
+      "short": "PgDn",
+      "med": "PageDn",
+      "long": "Page Down"
+    },
+    "79": {
+      "short": "→"
+    },
+    "80": {
+      "short": "←"
+    },
+    "81": {
+      "short": "↓"
+    },
+    "82": {
+      "short": "↑"
+    },
+    "83": {
+      "short": "Num",
+      "med": "NumLck",
+      "long": "Num Lock"
+    },
+    "84": {
+      "short": "/"
+    },
+    "85": {
+      "short": "*"
+    },
+    "86": {
+      "short": "-"
+    },
+    "87": {
+      "short": "+"
+    },
+    "88": {
+      "short": "Ent",
+      "med": "KP Ent",
+      "long": "KP Enter"
+    },
+    "89": {
+      "short": "1 En",
+      "med": "1 End"
+    },
+    "90": {
+      "short": "2 ↓"
+    },
+    "91": {
+      "short": "3 PD",
+      "med": "3 PgDn"
+    },
+    "92": {
+      "short": "4 ←"
+    },
+    "93": {
+      "short": "5"
+    },
+    "94": {
+      "short": "6 →"
+    },
+    "95": {
+      "short": "7 Hm",
+      "med": "7 Home"
+    },
+    "96": {
+      "short": "8 ↑"
+    },
+    "97": {
+      "short": "9 PU",
+      "med": "9 PgUp"
+    },
+    "98": {
+      "short": "0 In",
+      "med": "0 Ins",
+      "long": "0 Insert"
+    },
+    "99": {
+      "short": ". Dl",
+      "med": ". Del",
+      "long": ". Delete",
+      "icon": "delete"
+    },
+    "101": {
+      "short": "Appl",
+      "med": "Appl",
+      "long": "Applicat'n"
+    },
+    "102": {
+      "short": "Power",
+      "med": "Power"
+    },
+    "100": {
+      "short": "NUBS"
+    },
+    "103": {
+      "short": "="
+    },
+    "133": {
+      "short": ","
+    },
+    "134": {
+      "short": "="
+    },
+    "176": {
+      "short": "00"
+    },
+    "177": {
+      "short": "000"
+    },
+    "224": {
+      "short": "Ctrl",
+      "med": "L Ctrl",
+      "icon": "chevron-up"
+    },
+    "225": {
+      "short": "Shft",
+      "med": "L Shft",
+      "long": "L Shift",
+      "icon": "arrow-big-up"
+    },
+    "226": {
+      "short": "Alt",
+      "med": "L Alt",
+      "long": "Left Alt",
+      "icon": "option"
+    },
+    "227": {
+      "short": "GUI",
+      "med": "L GUI",
+      "long": "Left GUI",
+      "icon": "command"
+    },
+    "228": {
+      "short": "Ctrl",
+      "med": "R Ctrl",
+      "icon": "chevron-up"
+    },
+    "229": {
+      "short": "Shft",
+      "med": "R Shft",
+      "long": "R Shift",
+      "icon": "arrow-big-up"
+    },
+    "230": {
+      "short": "AltG",
+      "med": "AltGr"
+    },
+    "231": {
+      "short": "GUI",
+      "med": "R GUI",
+      "long": "Right GUI",
+      "icon": "command"
+    }
   },
   "12": {
-    "111": { "short": "🔆" },
-    "112": { "short": "🔅" },
-    "181": { "short": "⇥" },
-    "182": { "short": "⇤" },
-    "205": { "short": "⏯️" },
-    "226": { "short": "🔇" },
-    "233": { "short": "🔊" },
-    "234": { "short": "🔉" }
+    "111": {
+      "short": "🔆"
+    },
+    "112": {
+      "short": "🔅"
+    },
+    "181": {
+      "short": "⇥"
+    },
+    "182": {
+      "short": "⇤"
+    },
+    "205": {
+      "short": "⏯️"
+    },
+    "226": {
+      "short": "🔇"
+    },
+    "233": {
+      "short": "🔊",
+      "icon": "volume-2"
+    },
+    "234": {
+      "short": "🔉",
+      "icon": "volume-1"
+    }
   }
 }

--- a/src/hid-usages.ts
+++ b/src/hid-usages.ts
@@ -7,6 +7,7 @@ interface HidLabels {
   short?: string;
   med?: string;
   long?: string;
+  icon?: string;
 }
 
 const overrides: Record<string, Record<string, HidLabels>> = HidOverrides;
@@ -44,7 +45,7 @@ export const hid_usage_get_label = (
 export const hid_usage_get_labels = (
   usage_page: number,
   usage_id: number
-): { short?: string; med?: string; long?: string } =>
+): { short?: string; med?: string; long?: string; icon?: string } =>
   overrides[usage_page.toString()]?.[usage_id.toString()] || {
     short: UsagePages.find((p) => p.Id === usage_page)?.UsageIds?.find(
       (u) => u.Id === usage_id

--- a/src/keyboard/HidUsageLabel.tsx
+++ b/src/keyboard/HidUsageLabel.tsx
@@ -2,6 +2,7 @@ import {
   hid_usage_get_labels,
   hid_usage_page_and_id_from_usage,
 } from "../hid-usages";
+import * as icons from "lucide-react";
 
 export interface HidUsageLabelProps {
   hid_usage: number;
@@ -12,13 +13,29 @@ function remove_prefix(s?: string) {
 }
 
 export const HidUsageLabel = ({ hid_usage }: HidUsageLabelProps) => {
-  let [page, id] = hid_usage_page_and_id_from_usage(hid_usage);
+  const [page_raw, id] = hid_usage_page_and_id_from_usage(hid_usage);
 
   // TODO: Do something with implicit mods!
-  page &= 0xff;
+  const page = page_raw & 0xff;
 
-  let labels = hid_usage_get_labels(page, id);
+  const labels = hid_usage_get_labels(page, id);
 
+  // If an icon is defined, render it
+  if (labels.icon) {
+    // Convert kebab-case to PascalCase for the icon component name
+    const iconName = labels.icon
+      .split('-')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join('');
+
+    const IconComponent = (icons as unknown as Record<string, React.ComponentType<{ className?: string; 'aria-label'?: string }>>)[iconName];
+
+    if (IconComponent) {
+      return <IconComponent className="w-4 h-4" aria-label={remove_prefix(labels.short)} />;
+    }
+  }
+
+  // Fall back to text labels
   return (
     <span
       className="@[10em]:before:content-[attr(data-long-content)] @[6em]:before:content-[attr(data-med-content)] before:content-[attr(aria-label)]"


### PR DESCRIPTION
I felt like this was the simplest way to define which icons goes to which keycode. It might have to be expanded later with multiple icons, OS differences, etc.

![image](https://github.com/user-attachments/assets/327392cb-e95c-43d4-a657-578a09de1208)
