### PR TITLE
Generate Short Labels for Keys with Behaviors that don't have HID Code set as first Param

### DIFF
--- a/src/keyboard/KeyLabel.tsx
+++ b/src/keyboard/KeyLabel.tsx
@@ -1,0 +1,56 @@
+import {
+    hid_usage_get_labels,
+    hid_usage_page_and_id_from_usage,
+} from "../hid-usages";
+
+export interface KeyLabel {
+    hid_usage: number;
+    behavior_name: string;
+}
+
+function remove_prefix(s?: string) {
+    return s?.replace(/^Keyboard /, "");
+}
+
+function generate_short_label_from_behavior_name(behavior_name: string) {
+    // First remove "Keyboard" prefix if present
+    const clean_name = behavior_name.replace(/^Keyboard /, "");
+
+    // Check if name has sections divided by "_" and/or "-" delimiters
+    const sections = clean_name.split(/[_-]/);
+
+    if (sections.length > 1) {
+        // Take first letter of each section up to 3 letters
+        return sections.slice(0, 3).map(section => section.charAt(0)).join('').toUpperCase();
+    } else {
+        // No delimiters found, use first 3 letters of behavior name instead
+        return clean_name.substring(0, 3).toUpperCase();
+    }
+}
+
+export const KeyLabel = ({ hid_usage, behavior_name }: KeyLabel) => {
+    let [page, id] = hid_usage_page_and_id_from_usage(hid_usage);
+
+    // TODO: Do something with implicit mods!
+    page &= 0xff;
+
+    const labels = hid_usage_get_labels(page, id);
+
+    // If no HID short label is found/set, from the behavior's first parameter
+    if (!labels.short) {
+        if (behavior_name !== "None") {
+            labels.short = generate_short_label_from_behavior_name(behavior_name);
+        }
+    }
+
+    return (
+        <span
+            className="@[10em]:before:content-[attr(data-long-content)] @[6em]:before:content-[attr(data-med-content)] before:content-[attr(aria-label)]"
+            aria-label={remove_prefix(labels.short)}
+            data-med-content={remove_prefix(labels.med || labels.short)}
+            data-long-content={remove_prefix(
+                labels.long || labels.med || labels.short
+            )}
+        />
+    );
+};

--- a/src/keyboard/Keymap.tsx
+++ b/src/keyboard/Keymap.tsx
@@ -8,7 +8,7 @@ import {
   LayoutZoom,
   PhysicalLayout as PhysicalLayoutComp,
 } from "./PhysicalLayout";
-import { HidUsageLabel } from "./HidUsageLabel";
+import { KeyLabel } from "./KeyLabel";
 
 type BehaviorMap = Record<number, GetBehaviorDetailsResponse>;
 
@@ -61,8 +61,12 @@ export const Keymap = ({
       rx: (k.rx || 0) / 100.0,
       ry: (k.ry || 0) / 100.0,
       children: (
-        <HidUsageLabel
+        <KeyLabel
           hid_usage={keymap.layers[selectedLayerIndex].bindings[i].param1}
+          behavior_name={
+            behaviors[keymap.layers[selectedLayerIndex].bindings[i].behaviorId]
+              ?.displayName || "Unknown"
+          }
         />
       ),
     };


### PR DESCRIPTION
The un-hovered boxes showing nothing bothers me alot. This method isn't ideal either, but it shows that something is atleast populated on the key

1. Still Checks for label from `hid_usage` prop and renders the same as before this PR
2. If no label exists (either HID Code not in `hid-usage-name-overrides.json` or just not a HID Code) it will start using the behavior name provided by the added `behavior_name` prop to generate a short label
3. First use "_" & "-" as delimiters between sections, grabs first letter between sections upto 3
4. If "_" & "-" are not present, uses first 3 letters of behavior name instead


Works with custom behaviors too (pictured)


<img width="462" alt="Layer 2 - Shift It" src="https://github.com/user-attachments/assets/2fa9dbd9-e7e6-4d27-8427-e06e8f05c609" />

<img width="466" alt="BLU BLU" src="https://github.com/user-attachments/assets/b8ed3a7b-4c0c-4d0d-a336-d17c0766b707" />
