### PR TITLE
Show "Unnamed keyboard" rather than "TODO"

### DIFF
--- a/src-tauri/src/transport/serial.rs
+++ b/src-tauri/src/transport/serial.rs
@@ -77,7 +77,7 @@ pub async fn serial_list_devices(app_handle: AppHandle) -> Result<Vec<super::com
             if let SerialPortType::UsbPort(u) = pi.port_type {
                 Some(super::commands::AvailableDevice {
                     id: pi.port_name,
-                    label: u.product.unwrap_or("TODO".to_string()),
+                    label: u.product.unwrap_or("Unnamed keyboard".to_string()),
                 })
             } else {
                 None

--- a/src-tauri/src/transport/serial.rs
+++ b/src-tauri/src/transport/serial.rs
@@ -77,7 +77,7 @@ pub async fn serial_list_devices(app_handle: AppHandle) -> Result<Vec<super::com
             if let SerialPortType::UsbPort(u) = pi.port_type {
                 Some(super::commands::AvailableDevice {
                     id: pi.port_name,
-                    label: u.product.unwrap_or("Unnamed keyboard".to_string()),
+                    label: u.product.unwrap_or("Unnamed device".to_string()),
                 })
             } else {
                 None


### PR DESCRIPTION
If (due to a firmware configuration typo in my case) the keyboard's name is blank (at the USB level), ZMK Studio v0.3.1 would report it as "TODO" at the keyboard selection stage, which was confusing.

Example (the double listing is a separate issue perhaps on the keyboard firmware side):

<img width="912" height="712" alt="Screenshot 2025-08-06 at 17 04 08" src="https://github.com/user-attachments/assets/a89f0b60-2096-4eaa-bbf4-a3637aeb0be3" />
