### PR TITLE
Add key headers outside of hover state

### DIFF
--- a/src/keyboard/Key.tsx
+++ b/src/keyboard/Key.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren } from "react";
+import BehaviorShortNames from "./behavior-short-names.json";
 
 interface KeyProps {
   selected?: boolean;
@@ -7,6 +8,30 @@ interface KeyProps {
   oneU: number;
   header?: string;
   onClick?: () => void;
+}
+
+interface BehaviorShortName {
+  short?: string;
+}
+
+const MAX_HEADER_LENGTH = 9;
+const shortNames: Record<string, BehaviorShortName> = BehaviorShortNames;
+
+const shortenHeader = (header: string | undefined) => {
+  if(typeof header === "undefined"){
+    return "";
+  }
+  // Empty string is a valid header for behaviors where we don't want to see a header, which is falsy
+  // So we use an undefined check here
+  if(typeof shortNames[header]?.short !== "undefined"){
+    return shortNames[header].short;
+  } else if(header.length > MAX_HEADER_LENGTH){
+    const words = header.split(/[\s,-]+/);
+    const lettersPerWord = Math.trunc(MAX_HEADER_LENGTH / words.length);
+    return words.map((word) => (word.substring(0,lettersPerWord))).join("");
+  } else {
+    return header;
+  }
 }
 
 export const Key = ({
@@ -31,7 +56,7 @@ export const Key = ({
       }}
       onClick={onClick}
     >
-      <div className={`absolute text-xs ${selected ? "text-primary-content" : "z1text-base-content"} opacity-0 group-hover:opacity-80 top-1 text-nowrap left-1/2 font-light -translate-x-1/2 text-center transition-opacity`}>{header}</div>
+      <div className={`absolute text-xs ${selected ? "text-primary-content" : "z1text-base-content"} opacity-80 top-1 text-nowrap left-1/2 font-light -translate-x-1/2 text-center`}>{shortenHeader(header)}</div>
       {children}
     </button>
   );

--- a/src/keyboard/behavior-short-names.json
+++ b/src/keyboard/behavior-short-names.json
@@ -1,0 +1,14 @@
+{
+    "Key Press": {"short": ""},
+    "Bootloader": {"short": "Bootloadr"},
+    "External Power": {"short": "Ext Pwr"},
+    "Grave/Escape": {"short": "Grv/Esc"},
+    "Key Repeat": {"short": "Key Rept"},
+    "Key Toggle": {"short": "Key Togg"},
+    "Momentary Layer": {"short": "MLayer"},
+    "Output Selection": {"short": "OutputSel"},
+    "Sticky Key": {"short": "Stcky Key"},
+    "Studio Unlock": {"short": "Unlock"},
+    "Toggle Layer": {"short": "Togg Layr"},
+    "Transparent": {"short": "Transprnt"}
+}


### PR DESCRIPTION
Right now, ZMK Studio will show a blank key on keys that have any behavior set other than Key Press.

So at a glance, there isn't an easy way to differentiate between truly unbound keys, transparent keys, and keys with other behaviors assigned, such as studio unlock, bluetooth configuration, layer tap, mod tap, etc.

In order to see the behavior name, you have to hover over the key. This isn't ideal for a number of reasons.

This change adds key headers to keys at rest, without hover state.

There is one key challenge though - which is the space. If the header overflows the key, the UI will look like a mess. To handle this, I implemented a very simple heuristic (which should probably be discussed more).

If there are 10 characters or more, we try to split the behavior name into separate words (separated by a space or -) and then shorten each part equally to fit into 9 characters. This should handle most well formed behavior names, which are usually 2-3 words long.

If the human readable name of the behavior is 9 characters or less, we assume it'll fit on the key, and just display it as is.

Here's a few examples of what it looks like:
<img width="491" height="250" alt="image" src="https://github.com/user-attachments/assets/b3d53de3-647c-4803-aca3-35d8642ee6c6" />
<img width="737" height="746" alt="image" src="https://github.com/user-attachments/assets/94788045-1d4a-45be-a41f-016d7e1de5ae" />


This meant to be up for discussion, this is just a starting point.