### PR TITLE
ci: Fix path to signtool.exe on windows-2025 image

### DIFF
--- a/.github/workflows/tauri-build.yml
+++ b/.github/workflows/tauri-build.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Windows Kit into PATH (windows only)
         if: matrix.platform == 'windows-latest'
         run: |
-          echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.22621.0\x64\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\10.0.26100.0\x64\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: setup node
         uses: actions/setup-node@v4


### PR DESCRIPTION
The windows-latest tag now points to windows-2025, which only has a newer Windows SDK installed, so update the path to include the correct location for signtool.exe used for our app signing.

New version picked from https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md#installed-windows-sdks versus https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#installed-windows-sdks