### PR TITLE
fix: Update copyright year from 2024 to 2026

### DIFF
--- a/src/AppFooter.tsx
+++ b/src/AppFooter.tsx
@@ -10,7 +10,7 @@ export const AppFooter = ({
   return (
     <div className="grid justify-center p-1 bg-base-200">
       <div>
-        <span>&copy; 2024 - The ZMK Contributors</span> -{" "}
+        <span>&copy; 2026 - The ZMK Contributors</span> -{" "}
         <a className="hover:text-primary hover:cursor-pointer" onClick={onShowAbout}>
           About ZMK Studio
         </a>{" "}


### PR DESCRIPTION
## Summary
- Updates the copyright year in the footer from 2024 to 2026

## Test plan
- [ ] Verify the footer displays "© 2026 - The ZMK Contributors"