### PR TITLE
fix: honor an explicit zero rotation origin for keys

### DIFF
--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -56,8 +56,11 @@ function scalePosition(
   const transformStyle = "preserve-3d";
 
   if (r) {
-    let transformX = ((rx || x) - x) * oneU;
-    let transformY = ((ry || y) - y) * oneU;
+    // Use `??` so an explicit rotation origin of 0 is honored; `rx || x`
+    // collapsed a legitimate 0 back to the key's own position, pivoting the
+    // key around its own corner instead of the layout origin (#97).
+    let transformX = ((rx ?? x) - x) * oneU;
+    let transformY = ((ry ?? y) - y) * oneU;
     transformOrigin = `${transformX}px ${transformY}px`;
     transform = `rotate(${r}deg)`;
   }


### PR DESCRIPTION
## Problem

Fixes #97.

Keys with a rotation (`r != 0`) whose rotation origin `rx`/`ry` is **explicitly `0`** are pivoted around each key's own corner instead of the layout origin `(0,0)`. On boards that rotate clusters about the origin this scrambles the layout, as reported in #97.

The cause is in `scalePosition`:

```ts
let transformX = ((rx || x) - x) * oneU;
let transformY = ((ry || y) - y) * oneU;
```

`rx || x` treats a legitimate `0` as falsy and falls back to the key's own `x`, so `transformX` becomes `0` (pivot at the key's own corner) instead of `-x * oneU` (pivot at the layout origin).

## Fix

Use `??` so an explicit `0` is preserved:

```ts
let transformX = ((rx ?? x) - x) * oneU;
let transformY = ((ry ?? y) - y) * oneU;
```

When `rx`/`ry` are non-zero or omitted the behavior is unchanged; only the explicit-zero case is corrected.

## Verification

Verified locally in Storybook with a layout containing a thumb cluster rotated about a shared origin plus a key rotated about `(0,0)`: rotated clusters stay connected and the zero-origin key is positioned correctly. `tsc` and `eslint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)