### PR TITLE
fix: Prevent keys from disappearing after hover in Firefox

### DIFF
--- a/src/keyboard/PhysicalLayout.tsx
+++ b/src/keyboard/PhysicalLayout.tsx
@@ -124,11 +124,10 @@ export const PhysicalLayout = ({
     .reduce((a, b) => Math.max(a, b), 0);
 
   const positionItems = positions.map((p, idx) => (
-    <div className="absolute" style={scalePosition(p, oneU)}>
+    <div className="absolute hover:z-10" style={scalePosition(p, oneU)}>
       <div
         key={p.id}
         onClick={() => onPositionClicked?.(idx)}
-        className="hover:[transform:translateZ(100px)] transition-transform duration-200"
       >
         <Key
           oneU={oneU}


### PR DESCRIPTION
I observed this issue with Firefox 152. Keys don't disappear consistently, but will eventually if you hover over different keys.

Note that this issue is not present on https://zmk.studio/ since that is running an older version of ZMK Studio.

This issue was introduced in #141. You can observe issue on a build that includes that PR such as https://deploy-preview-170.preview.zmk.studio/.

The latest release 0.3.1 also has other display issues in Firefox that #141 addresses. Ideally there can be a new release with this fix to accommodate Firefox, which introduced Web Serial support in Firefox 151.

Example of issue:

<img width="1176" height="487" alt="firefox-hover-missing" src="https://github.com/user-attachments/assets/d0bcd1f9-1a31-47ab-876b-d1c3d3ad337d" />